### PR TITLE
End-to-end local Docker deploy with FastAPI demo + destroy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,54 @@ go build -o bin/openporch ./cmd/openporch
 
 Requires `tofu` on PATH (`brew install opentofu`).
 
+### Real Docker deploy (FastAPI demo)
+
+`examples/apps/fastapi-demo/` is a runnable FastAPI app whose `/health`
+endpoint queries a real Postgres container. The local-Docker modules under
+`examples/platform/` provision both via `kreuzwerker/docker`.
+
+```bash
+docker build -t fastapi-demo:local examples/apps/fastapi-demo
+./bin/openporch deploy examples/apps/fastapi-demo/manifest.yaml \
+    --platform examples/platform --project demo --env dev --env-type local
+curl http://localhost:8080/health   # {"db":"ok"}
+./bin/openporch destroy examples/apps/fastapi-demo/manifest.yaml \
+    --platform examples/platform --project demo --env dev --env-type local
+```
+
+### Integration tests
+
+The end-to-end Docker test lives behind a build tag so the default
+`go test ./...` stays hermetic:
+
+```bash
+go test -tags=integration -timeout=5m ./internal/deploy/...
+```
+
+It is skipped automatically when `docker version` fails.
+
+## State layout
+
+Everything openporch writes lives under `--state-root` (default `.openporch/`):
+
+```
+.openporch/
+  state/<project>/<env>/<resource>/   # main.tf, module/main.tf, terraform.tfstate, outputs.json
+  logs/<project>/<env>/<deployment>/  # per-resource tofu apply/destroy logs
+  plugin-cache/                       # shared TF_PLUGIN_CACHE_DIR
+```
+
+Lifecycle:
+
+- **Apply** is idempotent — re-running `deploy` rerenders `main.tf` and lets
+  tofu reconcile.
+- **Destroy** (`openporch destroy --prune`) reverses the deploy in reverse
+  topo order, then removes the resource working directories. Logs are kept.
+- The `plugin-cache/` is shared across deploys; safe to delete to reclaim
+  disk, will be repopulated on next `init`.
+- `outputs.json` may contain secrets (e.g. generated DB passwords); treat
+  the state directory as secret-equivalent.
+
 ## Concepts
 
 - **ResourceType** — contract (output schema) for a class of provisioned thing.

--- a/cmd/openporch/cmd_destroy.go
+++ b/cmd/openporch/cmd_destroy.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krbrudeli/openporch/internal/config"
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/manifest"
+	"github.com/krbrudeli/openporch/internal/runner"
+	"github.com/krbrudeli/openporch/internal/store"
+)
+
+func newDestroyCmd() *cobra.Command {
+	var (
+		platformDir string
+		project     string
+		env         string
+		envType     string
+		stateRoot   string
+		tofuBinary  string
+		prune       bool
+	)
+	cmd := &cobra.Command{
+		Use:   "destroy <manifest.yaml>",
+		Short: "Tear down a previously deployed manifest",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+
+			cfg, err := config.Load(platformDir)
+			if err != nil {
+				return err
+			}
+			m, err := manifest.Load(args[0])
+			if err != nil {
+				return err
+			}
+			if project == "" {
+				project = m.Metadata.Project
+			}
+			if project == "" {
+				return fmt.Errorf("project not set: pass --project or set metadata.project")
+			}
+
+			s := &store.FS{Root: stateRoot}
+			r := &runner.LocalTofu{
+				BinaryPath:     tofuBinary,
+				PluginCacheDir: filepath.Join(stateRoot, "plugin-cache"),
+			}
+
+			res, err := deploy.Destroy(ctx, deploy.DestroyOptions{
+				Options: deploy.Options{
+					Manifest: m, Platform: cfg, Store: s, Runner: r,
+					ProjectID: project, EnvID: env, EnvTypeID: envType,
+				},
+				Prune: prune,
+			})
+			if res != nil {
+				if len(res.Destroyed) > 0 {
+					fmt.Println("Destroyed:")
+					for _, k := range res.Destroyed {
+						fmt.Printf("  %s\n", k)
+					}
+				}
+				if len(res.Skipped) > 0 {
+					fmt.Println("Skipped (no state on disk):")
+					for _, k := range res.Skipped {
+						fmt.Printf("  %s\n", k)
+					}
+				}
+			}
+			return err
+		},
+	}
+
+	cwd, _ := os.Getwd()
+	cmd.Flags().StringVar(&platformDir, "platform", filepath.Join(cwd, "platform"),
+		"directory holding platform config")
+	cmd.Flags().StringVar(&project, "project", "", "project ID (overrides manifest.metadata.project)")
+	cmd.Flags().StringVar(&env, "env", "default", "environment ID")
+	cmd.Flags().StringVar(&envType, "env-type", "local", "environment type")
+	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
+		"directory under which TF state and openporch metadata live")
+	cmd.Flags().StringVar(&tofuBinary, "tofu", "", "path to tofu binary (default: $PATH lookup)")
+	cmd.Flags().BoolVar(&prune, "prune", true,
+		"remove resource working directories after a successful destroy")
+	return cmd
+}

--- a/cmd/openporch/main.go
+++ b/cmd/openporch/main.go
@@ -18,7 +18,7 @@ platform-engineer-authored library of OpenTofu modules and rules, picks the
 right module for each (project, env, env_type), and runs OpenTofu to converge.`,
 		SilenceUsage: true,
 	}
-	root.AddCommand(newDeployCmd(), newValidateCmd(), newVersionCmd())
+	root.AddCommand(newDeployCmd(), newDestroyCmd(), newValidateCmd(), newVersionCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/examples/apps/fastapi-demo/.dockerignore
+++ b/examples/apps/fastapi-demo/.dockerignore
@@ -1,0 +1,6 @@
+.venv
+__pycache__
+*.pyc
+.pytest_cache
+.git
+.openporch

--- a/examples/apps/fastapi-demo/Dockerfile
+++ b/examples/apps/fastapi-demo/Dockerfile
@@ -1,0 +1,15 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+ENV UV_LINK_MODE=copy \
+    UV_COMPILE_BYTECODE=1 \
+    UV_PYTHON_DOWNLOADS=never
+
+COPY pyproject.toml ./
+COPY src ./src
+RUN uv sync --no-dev
+
+EXPOSE 8080
+
+CMD ["uv", "run", "--no-dev", "uvicorn", "fastapi_demo.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/examples/apps/fastapi-demo/manifest.yaml
+++ b/examples/apps/fastapi-demo/manifest.yaml
@@ -1,0 +1,21 @@
+apiVersion: openporch/v1alpha1
+kind: Application
+metadata:
+  name: fastapi-demo
+  project: demo
+workloads:
+  api:
+    type: workload
+    params:
+      image: fastapi-demo:local
+      host_port: 8080
+      container_port: 8080
+      env:
+        DATABASE_URL: ${resources.db.outputs.url}
+    resources:
+      db:
+        type: postgres
+        params:
+          size: small
+outputs:
+  api_url: ${workloads.api.outputs.url}

--- a/examples/apps/fastapi-demo/pyproject.toml
+++ b/examples/apps/fastapi-demo/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "fastapi-demo"
+version = "0.1.0"
+description = "openporch FastAPI demo app"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115",
+    "uvicorn[standard]>=0.32",
+    "psycopg[binary]>=3.2",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/fastapi_demo"]

--- a/examples/apps/fastapi-demo/src/fastapi_demo/main.py
+++ b/examples/apps/fastapi-demo/src/fastapi_demo/main.py
@@ -1,0 +1,27 @@
+import os
+
+import psycopg
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+app = FastAPI(title="fastapi-demo")
+
+
+@app.get("/")
+def root() -> dict:
+    return {"message": "hello", "service": "fastapi-demo"}
+
+
+@app.get("/health")
+def health() -> JSONResponse:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        return JSONResponse({"db": "missing DATABASE_URL"}, status_code=503)
+    try:
+        with psycopg.connect(url, connect_timeout=3) as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                cur.fetchone()
+        return JSONResponse({"db": "ok"})
+    except Exception as exc:
+        return JSONResponse({"db": "error", "detail": str(exc)}, status_code=503)

--- a/examples/platform/modules.yaml
+++ b/examples/platform/modules.yaml
@@ -1,34 +1,97 @@
-# All four modules are inline (no external provider) so the demo runs
-# without Docker/AWS credentials. Each emits the outputs declared by its
-# resource type. The v0 proof point is that env_type alone steers which
-# module gets picked — same manifest, different infra shape.
+# Local-Docker modules use the kreuzwerker/docker provider against the
+# host's docker daemon. Cloud modules remain inline fakes so the
+# env_type=production path still demos rule-based selection without
+# requiring AWS credentials.
 
 apiVersion: openporch/v1alpha1
 kind: Module
 id: postgres-local
 resource_type: postgres
 module_source: inline
+provider_mapping:
+  docker: docker.docker-default
+  random: random.random-default
 module_params:
   type: object
   properties:
     size: { type: string }
+    host_port: { type: integer }
 module_source_code: |-
+  terraform {
+    required_providers {
+      docker = {
+        source = "kreuzwerker/docker"
+      }
+      random = {
+        source  = "hashicorp/random"
+        version = "~> 3.6"
+      }
+    }
+  }
+
   variable "size" {
     type    = string
     default = "small"
   }
   variable "res_id" {
-    type    = string
-    default = "db"
+    type = string
   }
-  locals {
-    port = 5432
-    user = "demo"
-    pass = "localpass"
+  variable "host_port" {
+    type    = number
+    default = 5433
   }
-  output "url"  { value = "postgres://${local.user}:${local.pass}@localhost:${local.port}/${var.res_id}_${var.size}" }
-  output "host" { value = "localhost" }
-  output "port" { value = local.port }
+
+  resource "random_password" "this" {
+    length  = 16
+    special = false
+  }
+
+  resource "docker_image" "postgres" {
+    name         = "postgres:16-alpine"
+    keep_locally = true
+  }
+
+  resource "docker_container" "this" {
+    name  = "openporch-${var.res_id}"
+    image = docker_image.postgres.image_id
+    env = [
+      "POSTGRES_USER=demo",
+      "POSTGRES_PASSWORD=${random_password.this.result}",
+      "POSTGRES_DB=${var.res_id}",
+    ]
+    ports {
+      internal = 5432
+      external = var.host_port
+      ip       = "0.0.0.0"
+    }
+    healthcheck {
+      test     = ["CMD-SHELL", "pg_isready -U demo -d ${var.res_id}"]
+      interval = "2s"
+      timeout  = "2s"
+      retries  = 30
+    }
+    wait         = true
+    wait_timeout = 60
+    restart      = "unless-stopped"
+    labels {
+      label = "openporch.managed"
+      value = "true"
+    }
+  }
+
+  # url contains the random password. v0 doesn't propagate `sensitive` from
+  # child outputs to the root module, so we use nonsensitive() to let the
+  # value flow through to the orchestrator. Treat outputs.json on disk as
+  # secret-equivalent.
+  output "url" {
+    value = "postgres://demo:${nonsensitive(random_password.this.result)}@host.docker.internal:${var.host_port}/${var.res_id}"
+  }
+  output "host" {
+    value = "host.docker.internal"
+  }
+  output "port" {
+    value = var.host_port
+  }
 module_inputs:
   res_id: ${context.res_id}
 ---
@@ -65,29 +128,68 @@ kind: Module
 id: workload-local-docker
 resource_type: workload
 module_source: inline
+provider_mapping:
+  docker: docker.docker-default
 module_params:
   type: object
   properties:
-    image: { type: string }
+    image:          { type: string }
+    host_port:      { type: integer }
+    container_port: { type: integer }
     env:
       type: object
       additionalProperties: { type: string }
 module_source_code: |-
+  terraform {
+    required_providers {
+      docker = {
+        source = "kreuzwerker/docker"
+      }
+    }
+  }
+
+  variable "name" {
+    type = string
+  }
   variable "image" {
     type = string
+  }
+  variable "host_port" {
+    type    = number
+    default = 8080
+  }
+  variable "container_port" {
+    type    = number
+    default = 8080
   }
   variable "env" {
     type    = map(string)
     default = {}
   }
-  variable "name" {
-    type = string
+
+  resource "docker_image" "this" {
+    name         = var.image
+    keep_locally = true
   }
-  locals {
-    port = 8080
+
+  resource "docker_container" "this" {
+    name  = "openporch-${var.name}"
+    image = docker_image.this.image_id
+    env   = [for k, v in var.env : "${k}=${v}"]
+    ports {
+      internal = var.container_port
+      external = var.host_port
+      ip       = "0.0.0.0"
+    }
+    restart = "unless-stopped"
+    labels {
+      label = "openporch.managed"
+      value = "true"
+    }
   }
-  output "url"  { value = "http://localhost:${local.port}" }
-  output "name" { value = "local-${var.name}" }
+
+  output "url"  { value = "http://localhost:${var.host_port}" }
+  output "name" { value = docker_container.this.name }
 module_inputs:
   name: ${context.res_id}
 ---

--- a/examples/platform/providers.yaml
+++ b/examples/platform/providers.yaml
@@ -1,0 +1,20 @@
+apiVersion: openporch/v1alpha1
+kind: Provider
+id: docker-default
+provider_type: docker
+source: kreuzwerker/docker
+version_constraint: "~> 3.0"
+description: |-
+  Local Docker daemon. Host left unset so the provider falls back to the
+  DOCKER_HOST env var (or unix:///var/run/docker.sock by default), which
+  works for Docker Desktop on macOS and standard Linux installs.
+---
+apiVersion: openporch/v1alpha1
+kind: Provider
+id: random-default
+provider_type: random
+source: hashicorp/random
+version_constraint: "~> 3.6"
+description: |-
+  Stateless random_* resources. Used for generating per-deploy secrets like
+  the postgres password.

--- a/internal/deploy/destroy.go
+++ b/internal/deploy/destroy.go
@@ -1,0 +1,113 @@
+package deploy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/krbrudeli/openporch/internal/graph"
+	"github.com/krbrudeli/openporch/internal/match"
+)
+
+// DestroyOptions drives a single Destroy run. It mirrors Options where
+// fields overlap so callers can reuse the same setup for both phases.
+type DestroyOptions struct {
+	Options
+	// Prune removes the resource working directories under
+	// <state-root>/state/<project>/<env>/ after a successful destroy.
+	// Logs are kept regardless.
+	Prune bool
+}
+
+// DestroyResult summarises what happened.
+type DestroyResult struct {
+	DeploymentID string
+	Destroyed    []string // resource keys destroyed in order
+	Skipped      []string // resource keys with no state on disk
+}
+
+// Destroy reverses a previous deploy. It rebuilds the same graph as Run, then
+// walks resources in reverse-topo order calling Runner.Destroy on each one
+// that has a working directory on disk. Errors per-resource are aggregated;
+// every resource is attempted even if an earlier one fails.
+func Destroy(ctx context.Context, o DestroyOptions) (*DestroyResult, error) {
+	if o.DeploymentID == "" {
+		o.DeploymentID = "destroy-" + time.Now().UTC().Format("20060102T150405Z")
+	}
+	g, err := buildGraph(o.Options)
+	if err != nil {
+		return nil, fmt.Errorf("destroy: build graph: %w", err)
+	}
+	ordered, err := g.TopoSort()
+	if err != nil {
+		return nil, fmt.Errorf("destroy: topo sort: %w", err)
+	}
+	// Reverse for destroy.
+	reversed := make([]*graph.Node, len(ordered))
+	for i, n := range ordered {
+		reversed[len(ordered)-1-i] = n
+	}
+
+	res := &DestroyResult{DeploymentID: o.DeploymentID}
+	var firstErr error
+	for _, n := range reversed {
+		workdir := o.Store.ResourceDir(o.ProjectID, o.EnvID, n.Key)
+		if _, statErr := os.Stat(filepath.Join(workdir, "main.tf")); statErr != nil {
+			if errors.Is(statErr, os.ErrNotExist) {
+				res.Skipped = append(res.Skipped, n.Key)
+				continue
+			}
+			if firstErr == nil {
+				firstErr = fmt.Errorf("destroy: stat %s: %w", workdir, statErr)
+			}
+			continue
+		}
+		log := o.Store.LogFile(o.ProjectID, o.EnvID, n.Key, o.DeploymentID)
+		fmt.Fprintf(os.Stderr, "[openporch] destroying %s\n", n.Key)
+		if err := o.Runner.Destroy(ctx, workdir, log); err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("destroy: %s: %w (see %s)", n.Key, err, log)
+			}
+			continue
+		}
+		res.Destroyed = append(res.Destroyed, n.Key)
+		if o.Prune {
+			if err := os.RemoveAll(workdir); err != nil && firstErr == nil {
+				firstErr = fmt.Errorf("destroy: prune %s: %w", workdir, err)
+			}
+		}
+	}
+	return res, firstErr
+}
+
+// buildGraph reproduces the graph build logic from Run without applying.
+// Both Run and Destroy need the same node set + module resolution.
+func buildGraph(o Options) (*graph.Graph, error) {
+	mctx := match.Context{
+		ProjectID: o.ProjectID,
+		EnvID:     o.EnvID,
+		EnvTypeID: o.EnvTypeID,
+	}
+	res := resolverFromMatcher{rules: o.Platform.ModuleRules, known: o.Platform.ResourceTypes, ctx: mctx}
+	g, err := graph.Build(o.Manifest, o.Platform.Modules, res)
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range g.Nodes {
+		if n.ModuleID != "" {
+			continue
+		}
+		modID, err := res.Resolve(n)
+		if err != nil {
+			if errors.Is(err, graph.ErrSkipModuleResolution) {
+				return nil, fmt.Errorf("no module rule matches %s (type=%s)", n.Key, n.Type)
+			}
+			return nil, fmt.Errorf("resolve module for %s: %w", n.Key, err)
+		}
+		n.ModuleID = modID
+	}
+	return g, nil
+}

--- a/internal/deploy/integration_test.go
+++ b/internal/deploy/integration_test.go
@@ -1,0 +1,137 @@
+//go:build integration
+
+package deploy_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/krbrudeli/openporch/internal/config"
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/manifest"
+	"github.com/krbrudeli/openporch/internal/runner"
+	"github.com/krbrudeli/openporch/internal/store"
+)
+
+// TestDeployFastAPIToLocalDocker runs the full pipeline against the host's
+// docker daemon: builds the FastAPI image, deploys postgres + workload via
+// openporch, asserts /health responds with {"db":"ok"}, then tears down.
+//
+// Run with: go test -tags=integration -timeout=5m ./internal/deploy/...
+func TestDeployFastAPIToLocalDocker(t *testing.T) {
+	if err := exec.Command("docker", "version").Run(); err != nil {
+		t.Skipf("docker daemon not reachable: %v", err)
+	}
+
+	repoRoot := findRepoRoot(t)
+	platformDir := filepath.Join(repoRoot, "examples", "platform")
+	manifestPath := filepath.Join(repoRoot, "examples", "apps", "fastapi-demo", "manifest.yaml")
+	appDir := filepath.Join(repoRoot, "examples", "apps", "fastapi-demo")
+
+	// Build the image the manifest references.
+	imageTag := "fastapi-demo:integration"
+	if out, err := exec.Command("docker", "build", "-t", imageTag, appDir).CombinedOutput(); err != nil {
+		t.Fatalf("docker build: %v\n%s", err, out)
+	}
+
+	cfg, err := config.Load(platformDir)
+	if err != nil {
+		t.Fatalf("load platform: %v", err)
+	}
+	m, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+	// Override the image to the just-built tag and use a non-default port to
+	// avoid colliding with whatever the developer has running on 8080/5433.
+	m.Workloads["api"].Params["image"] = imageTag
+	m.Workloads["api"].Params["host_port"] = 18080
+	dbResource := m.Workloads["api"].Resources["db"]
+	if dbResource.Params == nil {
+		dbResource.Params = map[string]any{}
+	}
+	dbResource.Params["host_port"] = 15433
+	m.Workloads["api"].Resources["db"] = dbResource
+
+	stateRoot := t.TempDir()
+	const project = "integration"
+	const env = "test"
+
+	s := &store.FS{Root: stateRoot}
+	r := &runner.LocalTofu{
+		BinaryPath:     "",
+		PluginCacheDir: filepath.Join(stateRoot, "plugin-cache"),
+	}
+	opts := deploy.Options{
+		Manifest: m, Platform: cfg, Store: s, Runner: r,
+		ProjectID: project, EnvID: env, EnvTypeID: "local",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	// Always tear down, even if the test fails partway. We do this with
+	// t.Cleanup before calling Run so that a panic during Run still triggers
+	// destroy.
+	t.Cleanup(func() {
+		dctx, dcancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer dcancel()
+		if _, err := deploy.Destroy(dctx, deploy.DestroyOptions{Options: opts, Prune: true}); err != nil {
+			t.Logf("cleanup destroy: %v", err)
+		}
+	})
+
+	res, err := deploy.Run(ctx, opts)
+	if err != nil {
+		t.Fatalf("deploy.Run: %v", err)
+	}
+	if got := res.Outputs["api_url"]; got != "http://localhost:18080" {
+		t.Errorf("api_url = %q, want http://localhost:18080", got)
+	}
+
+	// Poll /health: the container needs a moment to start uvicorn and for
+	// postgres to accept connections through the host.docker.internal hop.
+	deadline := time.Now().Add(60 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		body, status, err := httpGet("http://localhost:18080/health")
+		if err == nil && status == 200 {
+			var got map[string]string
+			if err := json.Unmarshal(body, &got); err == nil && got["db"] == "ok" {
+				return // success
+			}
+			lastErr = err
+			t.Logf("/health body=%s parse-err=%v", string(body), err)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("/health never returned db=ok: lastErr=%v", lastErr)
+}
+
+func httpGet(url string) ([]byte, int, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	return body, resp.StatusCode, err
+}
+
+func findRepoRoot(t *testing.T) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// this file lives at <root>/internal/deploy/integration_test.go
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}


### PR DESCRIPTION
Replaces the inline-fake postgres-local and workload-local-docker modules with real kreuzwerker/docker modules, adds a runnable FastAPI demo app (uv + psycopg /health hitting Postgres), implements the missing destroy command, and locks the full pipeline in with an integration test.