### PR TITLE
Move example modules to disk; treat module_source as a real path

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,29 @@ Lifecycle:
 - `outputs.json` may contain secrets (e.g. generated DB passwords); treat
   the state directory as secret-equivalent.
 
+## Module layout
+
+Modules are real OpenTofu modules on disk (or referenced remotely). The
+example platform uses one directory per module under
+`examples/platform/modules/`:
+
+```
+examples/platform/
+  modules.yaml              # Module + ModuleRule registrations
+  modules/<id>/main.tf      # the actual OpenTofu code
+```
+
+`module_source` in `modules.yaml` accepts local paths
+(`./modules/postgres-local`), git URLs (`git::https://…`), and Terraform
+registry refs — `tofu init` fetches remote sources at apply time.
+
 ## Concepts
 
 - **ResourceType** — contract (output schema) for a class of provisioned thing.
-- **Module** — OpenTofu code that implements a resource type. Multiple modules
-  per type is the point: one for each environment variant.
+- **Module** — OpenTofu code that implements a resource type, referenced via
+  `module_source` (a local path under the platform directory, a git URL, or
+  a Terraform registry ref). Multiple modules per type is the point: one for
+  each environment variant.
 - **ModuleRule** — selector mapping `(resource_type, env_matchers) → module`.
 - **Provider** — central OpenTofu provider config, injected at the root TF.
 - **Runner** — execution backend. v0 ships only `local-tofu`.

--- a/api/v1alpha1/types.go
+++ b/api/v1alpha1/types.go
@@ -111,6 +111,9 @@ type RunnerRule struct {
 
 // PlatformConfig aggregates everything loaded from ./platform/.
 type PlatformConfig struct {
+	// RootDir is the absolute path of the directory the config was loaded
+	// from. Local module_source paths are resolved against this.
+	RootDir       string
 	ResourceTypes map[string]ResourceType
 	Modules       map[string]Module
 	ModuleRules   []ModuleRule

--- a/examples/platform/modules.yaml
+++ b/examples/platform/modules.yaml
@@ -1,13 +1,14 @@
 # Local-Docker modules use the kreuzwerker/docker provider against the
-# host's docker daemon. Cloud modules remain inline fakes so the
+# host's docker daemon. Cloud modules are stand-ins so the
 # env_type=production path still demos rule-based selection without
-# requiring AWS credentials.
+# requiring AWS credentials. Module sources point at directories under
+# ./modules/<id>/; one main.tf per module.
 
 apiVersion: openporch/v1alpha1
 kind: Module
 id: postgres-local
 resource_type: postgres
-module_source: inline
+module_source: ./modules/postgres-local
 provider_mapping:
   docker: docker.docker-default
   random: random.random-default
@@ -16,82 +17,6 @@ module_params:
   properties:
     size: { type: string }
     host_port: { type: integer }
-module_source_code: |-
-  terraform {
-    required_providers {
-      docker = {
-        source = "kreuzwerker/docker"
-      }
-      random = {
-        source  = "hashicorp/random"
-        version = "~> 3.6"
-      }
-    }
-  }
-
-  variable "size" {
-    type    = string
-    default = "small"
-  }
-  variable "res_id" {
-    type = string
-  }
-  variable "host_port" {
-    type    = number
-    default = 5433
-  }
-
-  resource "random_password" "this" {
-    length  = 16
-    special = false
-  }
-
-  resource "docker_image" "postgres" {
-    name         = "postgres:16-alpine"
-    keep_locally = true
-  }
-
-  resource "docker_container" "this" {
-    name  = "openporch-${var.res_id}"
-    image = docker_image.postgres.image_id
-    env = [
-      "POSTGRES_USER=demo",
-      "POSTGRES_PASSWORD=${random_password.this.result}",
-      "POSTGRES_DB=${var.res_id}",
-    ]
-    ports {
-      internal = 5432
-      external = var.host_port
-      ip       = "0.0.0.0"
-    }
-    healthcheck {
-      test     = ["CMD-SHELL", "pg_isready -U demo -d ${var.res_id}"]
-      interval = "2s"
-      timeout  = "2s"
-      retries  = 30
-    }
-    wait         = true
-    wait_timeout = 60
-    restart      = "unless-stopped"
-    labels {
-      label = "openporch.managed"
-      value = "true"
-    }
-  }
-
-  # url contains the random password. v0 doesn't propagate `sensitive` from
-  # child outputs to the root module, so we use nonsensitive() to let the
-  # value flow through to the orchestrator. Treat outputs.json on disk as
-  # secret-equivalent.
-  output "url" {
-    value = "postgres://demo:${nonsensitive(random_password.this.result)}@host.docker.internal:${var.host_port}/${var.res_id}"
-  }
-  output "host" {
-    value = "host.docker.internal"
-  }
-  output "port" {
-    value = var.host_port
-  }
 module_inputs:
   res_id: ${context.res_id}
 ---
@@ -99,27 +24,11 @@ apiVersion: openporch/v1alpha1
 kind: Module
 id: postgres-cloud
 resource_type: postgres
-module_source: inline
+module_source: ./modules/postgres-cloud
 module_params:
   type: object
   properties:
     size: { type: string }
-module_source_code: |-
-  variable "size" {
-    type    = string
-    default = "small"
-  }
-  variable "res_id" {
-    type    = string
-    default = "db"
-  }
-  locals {
-    cluster = "aurora-${var.res_id}"
-    region  = "us-east-1"
-  }
-  output "url"  { value = "postgres://appuser:CHANGE_ME@${local.cluster}.${local.region}.rds.amazonaws.com:5432/main" }
-  output "host" { value = "${local.cluster}.${local.region}.rds.amazonaws.com" }
-  output "port" { value = 5432 }
 module_inputs:
   res_id: ${context.res_id}
 ---
@@ -127,7 +36,7 @@ apiVersion: openporch/v1alpha1
 kind: Module
 id: workload-local-docker
 resource_type: workload
-module_source: inline
+module_source: ./modules/workload-local-docker
 provider_mapping:
   docker: docker.docker-default
 module_params:
@@ -139,57 +48,6 @@ module_params:
     env:
       type: object
       additionalProperties: { type: string }
-module_source_code: |-
-  terraform {
-    required_providers {
-      docker = {
-        source = "kreuzwerker/docker"
-      }
-    }
-  }
-
-  variable "name" {
-    type = string
-  }
-  variable "image" {
-    type = string
-  }
-  variable "host_port" {
-    type    = number
-    default = 8080
-  }
-  variable "container_port" {
-    type    = number
-    default = 8080
-  }
-  variable "env" {
-    type    = map(string)
-    default = {}
-  }
-
-  resource "docker_image" "this" {
-    name         = var.image
-    keep_locally = true
-  }
-
-  resource "docker_container" "this" {
-    name  = "openporch-${var.name}"
-    image = docker_image.this.image_id
-    env   = [for k, v in var.env : "${k}=${v}"]
-    ports {
-      internal = var.container_port
-      external = var.host_port
-      ip       = "0.0.0.0"
-    }
-    restart = "unless-stopped"
-    labels {
-      label = "openporch.managed"
-      value = "true"
-    }
-  }
-
-  output "url"  { value = "http://localhost:${var.host_port}" }
-  output "name" { value = docker_container.this.name }
 module_inputs:
   name: ${context.res_id}
 ---
@@ -197,7 +55,7 @@ apiVersion: openporch/v1alpha1
 kind: Module
 id: workload-aws-lambda
 resource_type: workload
-module_source: inline
+module_source: ./modules/workload-aws-lambda
 module_params:
   type: object
   properties:
@@ -205,18 +63,5 @@ module_params:
     env:
       type: object
       additionalProperties: { type: string }
-module_source_code: |-
-  variable "image" {
-    type = string
-  }
-  variable "env" {
-    type    = map(string)
-    default = {}
-  }
-  variable "name" {
-    type = string
-  }
-  output "url"  { value = "https://lambda-${var.name}.execute-api.us-east-1.amazonaws.com/prod" }
-  output "name" { value = "lambda-${var.name}" }
 module_inputs:
   name: ${context.res_id}

--- a/examples/platform/modules/postgres-cloud/main.tf
+++ b/examples/platform/modules/postgres-cloud/main.tf
@@ -1,0 +1,15 @@
+variable "size" {
+  type    = string
+  default = "small"
+}
+variable "res_id" {
+  type    = string
+  default = "db"
+}
+locals {
+  cluster = "aurora-${var.res_id}"
+  region  = "us-east-1"
+}
+output "url" { value = "postgres://appuser:CHANGE_ME@${local.cluster}.${local.region}.rds.amazonaws.com:5432/main" }
+output "host" { value = "${local.cluster}.${local.region}.rds.amazonaws.com" }
+output "port" { value = 5432 }

--- a/examples/platform/modules/postgres-local/main.tf
+++ b/examples/platform/modules/postgres-local/main.tf
@@ -1,0 +1,75 @@
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+variable "size" {
+  type    = string
+  default = "small"
+}
+variable "res_id" {
+  type = string
+}
+variable "host_port" {
+  type    = number
+  default = 5433
+}
+
+resource "random_password" "this" {
+  length  = 16
+  special = false
+}
+
+resource "docker_image" "postgres" {
+  name         = "postgres:16-alpine"
+  keep_locally = true
+}
+
+resource "docker_container" "this" {
+  name  = "openporch-${var.res_id}"
+  image = docker_image.postgres.image_id
+  env = [
+    "POSTGRES_USER=demo",
+    "POSTGRES_PASSWORD=${random_password.this.result}",
+    "POSTGRES_DB=${var.res_id}",
+  ]
+  ports {
+    internal = 5432
+    external = var.host_port
+    ip       = "0.0.0.0"
+  }
+  healthcheck {
+    test     = ["CMD-SHELL", "pg_isready -U demo -d ${var.res_id}"]
+    interval = "2s"
+    timeout  = "2s"
+    retries  = 30
+  }
+  wait         = true
+  wait_timeout = 60
+  restart      = "unless-stopped"
+  labels {
+    label = "openporch.managed"
+    value = "true"
+  }
+}
+
+# url contains the random password. v0 doesn't propagate `sensitive` from
+# child outputs to the root module, so we use nonsensitive() to let the
+# value flow through to the orchestrator. Treat outputs.json on disk as
+# secret-equivalent.
+output "url" {
+  value = "postgres://demo:${nonsensitive(random_password.this.result)}@host.docker.internal:${var.host_port}/${var.res_id}"
+}
+output "host" {
+  value = "host.docker.internal"
+}
+output "port" {
+  value = var.host_port
+}

--- a/examples/platform/modules/workload-aws-lambda/main.tf
+++ b/examples/platform/modules/workload-aws-lambda/main.tf
@@ -1,0 +1,12 @@
+variable "image" {
+  type = string
+}
+variable "env" {
+  type    = map(string)
+  default = {}
+}
+variable "name" {
+  type = string
+}
+output "url" { value = "https://lambda-${var.name}.execute-api.us-east-1.amazonaws.com/prod" }
+output "name" { value = "lambda-${var.name}" }

--- a/examples/platform/modules/workload-local-docker/main.tf
+++ b/examples/platform/modules/workload-local-docker/main.tf
@@ -1,0 +1,50 @@
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+    }
+  }
+}
+
+variable "name" {
+  type = string
+}
+variable "image" {
+  type = string
+}
+variable "host_port" {
+  type    = number
+  default = 8080
+}
+variable "container_port" {
+  type    = number
+  default = 8080
+}
+variable "env" {
+  type    = map(string)
+  default = {}
+}
+
+resource "docker_image" "this" {
+  name         = var.image
+  keep_locally = true
+}
+
+resource "docker_container" "this" {
+  name  = "openporch-${var.name}"
+  image = docker_image.this.image_id
+  env   = [for k, v in var.env : "${k}=${v}"]
+  ports {
+    internal = var.container_port
+    external = var.host_port
+    ip       = "0.0.0.0"
+  }
+  restart = "unless-stopped"
+  labels {
+    label = "openporch.managed"
+    value = "true"
+  }
+}
+
+output "url" { value = "http://localhost:${var.host_port}" }
+output "name" { value = docker_container.this.name }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,13 +21,18 @@ import (
 // Load reads every .yaml/.yml file under root, splits on YAML document
 // boundaries, and dispatches each document by kind into the platform config.
 func Load(root string) (*v1.PlatformConfig, error) {
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("config: resolve root %s: %w", root, err)
+	}
 	cfg := &v1.PlatformConfig{
+		RootDir:       absRoot,
 		ResourceTypes: map[string]v1.ResourceType{},
 		Modules:       map[string]v1.Module{},
 		Providers:     map[string]v1.Provider{},
 		Runners:       map[string]v1.Runner{},
 	}
-	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+	err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -206,7 +211,7 @@ func Validate(cfg *v1.PlatformConfig) error {
 				r.ID, r.RunnerID)
 		}
 	}
-	if err := validateInlineModuleHCL(cfg); err != nil {
+	if err := validateModuleHCL(cfg); err != nil {
 		return err
 	}
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -43,6 +43,12 @@ id: docker-default
 provider_type: docker
 source: kreuzwerker/docker
 `)
+	writeFile(t, filepath.Join(root, "modules", "postgres-docker"), "main.tf", `variable "size" {
+  type    = string
+  default = "small"
+}
+output "url" { value = "x" }
+`)
 	writeFile(t, root, "modules.yaml", `
 apiVersion: openporch/v1alpha1
 kind: Module
@@ -91,7 +97,7 @@ apiVersion: openporch/v1alpha1
 kind: Module
 id: bad
 resource_type: postgres
-module_source: x
+module_source: git::https://example.com/repo.git
 provider_mapping:
   docker: docker.aws-default   # mismatch: provider type is aws, not docker
 `)
@@ -201,7 +207,7 @@ func TestValidate_refusesSelfReferentialDep(t *testing.T) {
 	cfg := baseCfg()
 	cfg.Modules["postgres-self"] = v1.Module{
 		ID: "postgres-self", ResourceType: "postgres",
-		ModuleSource: "x",
+		ModuleSource: "git::https://example.com/repo.git",
 		Dependencies: map[string]v1.Dependency{
 			"replica": {Type: "postgres", ID: "@-r"},
 		},
@@ -219,13 +225,89 @@ func TestValidate_allowsExplicitSiblingDep(t *testing.T) {
 	cfg := baseCfg()
 	cfg.Modules["postgres-primary"] = v1.Module{
 		ID: "postgres-primary", ResourceType: "postgres",
-		ModuleSource: "x",
+		ModuleSource: "git::https://example.com/repo.git",
 		Dependencies: map[string]v1.Dependency{
 			"replica": {Type: "postgres", ID: "explicit-replica-id"},
 		},
 	}
 	if err := Validate(cfg); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_localModuleSource_acceptsGoodHCL(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "modules", "postgres-docker"), "main.tf",
+		`variable "size" {
+  type    = string
+  default = "small"
+}
+variable "res_id" {
+  type = string
+}
+output "url" { value = "postgres://localhost/${var.res_id}" }
+`)
+	cfg := baseCfg()
+	cfg.RootDir = root
+	cfg.Modules["postgres-docker"] = v1.Module{
+		ID: "postgres-docker", ResourceType: "postgres",
+		ModuleSource: "./modules/postgres-docker",
+		ModuleInputs: map[string]any{"res_id": "demo"},
+	}
+	if err := Validate(cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_localModuleSource_declaredButUnset(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "modules", "postgres-docker"), "main.tf",
+		`variable "missing" { type = string }
+`)
+	cfg := baseCfg()
+	cfg.RootDir = root
+	cfg.Modules["postgres-docker"] = v1.Module{
+		ID: "postgres-docker", ResourceType: "postgres",
+		ModuleSource: "./modules/postgres-docker",
+	}
+	err := Validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("want declared-but-unset error mentioning %q, got: %v", "missing", err)
+	}
+}
+
+func TestValidate_localModuleSource_setButUndeclared(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "modules", "postgres-docker"), "main.tf",
+		`variable "size" {
+  type    = string
+  default = "small"
+}
+`)
+	cfg := baseCfg()
+	cfg.RootDir = root
+	cfg.Modules["postgres-docker"] = v1.Module{
+		ID: "postgres-docker", ResourceType: "postgres",
+		ModuleSource: "./modules/postgres-docker",
+		ModuleInputs: map[string]any{"phantom": "x"},
+	}
+	err := Validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "phantom") {
+		t.Fatalf("want set-but-undeclared error mentioning %q, got: %v", "phantom", err)
+	}
+}
+
+func TestValidate_localModuleSource_missingDir(t *testing.T) {
+	root := t.TempDir()
+	cfg := baseCfg()
+	cfg.RootDir = root
+	cfg.Modules["postgres-docker"] = v1.Module{
+		ID: "postgres-docker", ResourceType: "postgres",
+		ModuleSource: "./modules/does-not-exist",
+	}
+	err := Validate(cfg)
+	if err == nil || !strings.Contains(err.Error(), "postgres-docker") {
+		t.Fatalf("want error naming module, got: %v", err)
 	}
 }
 

--- a/internal/config/hcl.go
+++ b/internal/config/hcl.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -9,34 +11,107 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 
 	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+	"github.com/krbrudeli/openporch/internal/tofu"
 )
 
-// validateInlineModuleHCL parses every Module.ModuleSourceCode and accumulates
-// HCL diagnostics. Each module ID is iterated in sorted order so that error
-// messages are deterministic across runs.
-func validateInlineModuleHCL(cfg *v1.PlatformConfig) error {
+// validateModuleHCL parses each Module's source HCL — either inline source
+// code or the .tf files at a local module_source path — and accumulates HCL
+// diagnostics. Each module ID is iterated in sorted order so that error
+// messages are deterministic across runs. Remote module sources (git,
+// registry, http) are skipped; tofu init catches shape mismatches there.
+func validateModuleHCL(cfg *v1.PlatformConfig) error {
 	ids := make([]string, 0, len(cfg.Modules))
-	for id, m := range cfg.Modules {
-		if m.ModuleSourceCode != "" {
-			ids = append(ids, id)
-		}
+	for id := range cfg.Modules {
+		ids = append(ids, id)
 	}
 	sort.Strings(ids)
 
 	for _, id := range ids {
 		m := cfg.Modules[id]
-		filename := "modules/" + id + ".tf"
-		parser := hclparse.NewParser()
-		file, diags := parser.ParseHCL([]byte(m.ModuleSourceCode), filename)
-		if diags.HasErrors() {
-			return fmt.Errorf("config: module %q inline source: %s",
-				id, formatHCLDiags(diags))
+		bodies, err := parseModuleHCL(cfg, m)
+		if err != nil {
+			return err
 		}
-		if err := checkInlineVarsAgainstInputsAndParams(id, m, file.Body); err != nil {
+		if bodies == nil {
+			continue
+		}
+		if err := checkVarsAgainstInputsAndParams(id, m, bodies); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// parseModuleHCL returns the parsed top-level bodies for the module's HCL,
+// or (nil, nil) if there's nothing to validate (remote source, no inline
+// code).
+func parseModuleHCL(cfg *v1.PlatformConfig, m v1.Module) ([]*hclsyntax.Body, error) {
+	if m.ModuleSourceCode != "" {
+		filename := "modules/" + m.ID + ".tf"
+		parser := hclparse.NewParser()
+		file, diags := parser.ParseHCL([]byte(m.ModuleSourceCode), filename)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("config: module %q inline source: %s",
+				m.ID, formatHCLDiags(diags))
+		}
+		body, ok := file.Body.(*hclsyntax.Body)
+		if !ok {
+			return nil, nil
+		}
+		return []*hclsyntax.Body{body}, nil
+	}
+	if m.ModuleSource == "" || m.ModuleSource == "inline" {
+		return nil, nil
+	}
+	if !tofu.IsLocalSource(m.ModuleSource) {
+		return nil, nil
+	}
+	dir, err := tofu.ResolveSource(m.ModuleSource, cfg.RootDir)
+	if err != nil {
+		return nil, fmt.Errorf("config: module %q: %w", m.ID, err)
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return nil, fmt.Errorf("config: module %q source %q: %w", m.ID, dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("config: module %q source %q: not a directory", m.ID, dir)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("config: module %q source %q: %w", m.ID, dir, err)
+	}
+	var tfFiles []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".tf") {
+			tfFiles = append(tfFiles, filepath.Join(dir, name))
+		}
+	}
+	if len(tfFiles) == 0 {
+		return nil, fmt.Errorf("config: module %q source %q: no .tf files found", m.ID, dir)
+	}
+	sort.Strings(tfFiles)
+	bodies := make([]*hclsyntax.Body, 0, len(tfFiles))
+	for _, path := range tfFiles {
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("config: module %q read %s: %w", m.ID, path, err)
+		}
+		parser := hclparse.NewParser()
+		file, diags := parser.ParseHCL(b, path)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("config: module %q source %s: %s",
+				m.ID, path, formatHCLDiags(diags))
+		}
+		if body, ok := file.Body.(*hclsyntax.Body); ok {
+			bodies = append(bodies, body)
+		}
+	}
+	return bodies, nil
 }
 
 func formatHCLDiags(diags interface{ Error() string }) string {
@@ -45,28 +120,26 @@ func formatHCLDiags(diags interface{ Error() string }) string {
 	return strings.TrimRight(diags.Error(), "\n")
 }
 
-// checkInlineVarsAgainstInputsAndParams walks the parsed body, finds every
-// top-level `variable "<name>"` block, and cross-references the names against
-// Module.ModuleInputs and Module.ModuleParams. It surfaces both directions:
-// a variable with no default that nothing supplies, and a module_inputs key
-// that doesn't correspond to any declared variable.
-func checkInlineVarsAgainstInputsAndParams(id string, m v1.Module, body interface{}) error {
-	syntaxBody, ok := body.(*hclsyntax.Body)
-	if !ok {
-		return nil
-	}
-
-	declared := map[string]bool{} // name -> hasDefault
+// checkVarsAgainstInputsAndParams walks the parsed bodies, finds every
+// top-level `variable "<name>"` block across all of them, and
+// cross-references the names against Module.ModuleInputs and
+// Module.ModuleParams. It surfaces both directions: a variable with no
+// default that nothing supplies, and a module_inputs key that doesn't
+// correspond to any declared variable.
+func checkVarsAgainstInputsAndParams(id string, m v1.Module, bodies []*hclsyntax.Body) error {
+	declared := map[string]bool{}
 	hasDefault := map[string]bool{}
-	for _, blk := range syntaxBody.Blocks {
-		if blk.Type != "variable" || len(blk.Labels) != 1 {
-			continue
-		}
-		name := blk.Labels[0]
-		declared[name] = true
-		if blk.Body != nil {
-			if _, ok := blk.Body.Attributes["default"]; ok {
-				hasDefault[name] = true
+	for _, body := range bodies {
+		for _, blk := range body.Blocks {
+			if blk.Type != "variable" || len(blk.Labels) != 1 {
+				continue
+			}
+			name := blk.Labels[0]
+			declared[name] = true
+			if blk.Body != nil {
+				if _, ok := blk.Body.Attributes["default"]; ok {
+					hasDefault[name] = true
+				}
 			}
 		}
 	}
@@ -83,13 +156,13 @@ func checkInlineVarsAgainstInputsAndParams(id string, m v1.Module, body interfac
 		if _, ok := paramKeys[name]; ok {
 			continue
 		}
-		return fmt.Errorf("config: module %q inline source declares variable %q but no module_inputs or module_params property sets it",
+		return fmt.Errorf("config: module %q module source declares variable %q but no module_inputs or module_params property sets it",
 			id, name)
 	}
 
 	for name := range m.ModuleInputs {
 		if !declared[name] {
-			return fmt.Errorf("config: module %q module_inputs sets %q but the inline source declares no such variable",
+			return fmt.Errorf("config: module %q module_inputs sets %q but the module source declares no such variable",
 				id, name)
 		}
 	}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -174,11 +174,17 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		outNames := outputNamesForType(o.Platform.ResourceTypes[n.Type])
 
 		moduleSource := mod.ModuleSource
-		if mod.ModuleSourceCode != "" {
+		if mod.ModuleSource == "inline" || mod.ModuleSourceCode != "" {
 			if err := o.Store.WriteInlineModule(o.ProjectID, o.EnvID, n.Key, mod.ModuleSourceCode); err != nil {
 				return nil, err
 			}
 			moduleSource = "./module"
+		} else {
+			resolved, err := tofu.ResolveSource(mod.ModuleSource, o.Platform.RootDir)
+			if err != nil {
+				return nil, fmt.Errorf("deploy: resolve module source for %s: %w", n.Key, err)
+			}
+			moduleSource = resolved
 		}
 		hcl, err := tofu.Render(tofu.Plan{
 			ModuleSource:    moduleSource,

--- a/internal/tofu/source.go
+++ b/internal/tofu/source.go
@@ -1,0 +1,71 @@
+package tofu
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// ResolveSource turns a Module.ModuleSource into the string that should
+// appear in `module "main" { source = ... }`.
+//
+//   - "inline"             -> "./module" (caller writes the inline HCL)
+//   - relative local path  -> absolute path under platformRoot
+//   - remote (git::, github.com/, registry.*, https://, ...) -> verbatim
+func ResolveSource(raw, platformRoot string) (string, error) {
+	if raw == "" {
+		return "", fmt.Errorf("tofu: empty module source")
+	}
+	if raw == "inline" {
+		return "./module", nil
+	}
+	if !IsLocalSource(raw) {
+		return raw, nil
+	}
+	if filepath.IsAbs(raw) {
+		return filepath.Clean(raw), nil
+	}
+	abs, err := filepath.Abs(filepath.Join(platformRoot, raw))
+	if err != nil {
+		return "", fmt.Errorf("tofu: resolve local module source %q under %q: %w", raw, platformRoot, err)
+	}
+	return abs, nil
+}
+
+// IsLocalSource reports whether raw should be treated as a filesystem path
+// relative to the platform root (or an absolute path) rather than a remote
+// reference. The "inline" sentinel is not a local path.
+func IsLocalSource(raw string) bool {
+	if raw == "" || raw == "inline" {
+		return false
+	}
+	if strings.HasPrefix(raw, "./") || strings.HasPrefix(raw, "../") {
+		return true
+	}
+	if filepath.IsAbs(raw) {
+		return true
+	}
+	if strings.Contains(raw, "::") {
+		return false
+	}
+	if strings.HasPrefix(raw, "git@") {
+		return false
+	}
+	if strings.HasPrefix(raw, "http://") || strings.HasPrefix(raw, "https://") {
+		return false
+	}
+	remoteHostPrefixes := []string{
+		"github.com/",
+		"bitbucket.org/",
+		"registry.terraform.io/",
+		"app.terraform.io/",
+	}
+	for _, p := range remoteHostPrefixes {
+		if strings.HasPrefix(raw, p) {
+			return false
+		}
+	}
+	// Bare paths like "foo/bar" are local subdirectories per Terraform's
+	// own module-source parsing.
+	return true
+}

--- a/internal/tofu/source_test.go
+++ b/internal/tofu/source_test.go
@@ -1,0 +1,95 @@
+package tofu
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveSource_inline(t *testing.T) {
+	got, err := ResolveSource("inline", "/anywhere")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "./module" {
+		t.Fatalf("got %q, want ./module", got)
+	}
+}
+
+func TestResolveSource_localRelative(t *testing.T) {
+	root := t.TempDir()
+	got, err := ResolveSource("./modules/postgres", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "modules", "postgres")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveSource_localParent(t *testing.T) {
+	root := t.TempDir()
+	got, err := ResolveSource("../shared/postgres", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := filepath.Abs(filepath.Join(root, "../shared/postgres"))
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolveSource_remoteVerbatim(t *testing.T) {
+	cases := []string{
+		"git::https://example.com/foo.git//modules/postgres",
+		"registry.terraform.io/hashicorp/consul/aws",
+		"github.com/org/repo//modules/postgres",
+		"https://example.com/module.zip",
+		"git@github.com:org/repo.git",
+	}
+	for _, raw := range cases {
+		got, err := ResolveSource(raw, "/somewhere")
+		if err != nil {
+			t.Fatalf("%q: %v", raw, err)
+		}
+		if got != raw {
+			t.Fatalf("%q: got %q, want verbatim", raw, got)
+		}
+	}
+}
+
+func TestResolveSource_bareAsLocal(t *testing.T) {
+	root := t.TempDir()
+	got, err := ResolveSource("modules/postgres", root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(root, "modules", "postgres")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestIsLocalSource(t *testing.T) {
+	cases := map[string]bool{
+		"./foo":                      true,
+		"../foo":                     true,
+		"/abs/foo":                   true,
+		"foo/bar":                    true,
+		"inline":                     false,
+		"":                           false,
+		"git::https://x/y.git":       false,
+		"github.com/org/repo":        false,
+		"bitbucket.org/org/repo":     false,
+		"registry.terraform.io/x/y":  false,
+		"app.terraform.io/x/y":       false,
+		"https://example.com/x.zip":  false,
+		"http://example.com/x.zip":   false,
+		"git@github.com:org/repo":    false,
+	}
+	for in, want := range cases {
+		if got := IsLocalSource(in); got != want {
+			t.Errorf("IsLocalSource(%q) = %v, want %v", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Replaces inline HCL strings in modules.yaml with on-disk module
directories (examples/platform/modules/<id>/main.tf), matching
Humanitec's convention. Adds tofu.ResolveSource so deploy can pass
local-relative paths and remote refs through to OpenTofu, and
generalises the HCL validator to read variable blocks from .tf files
when module_source is a local path.

Inline modules still work (used by tests).