### PR TITLE
Add CI workflow for automated testing and verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Set up OpenTofu
         uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false
 
       - name: Integration tests
         run: go test -tags=integration -timeout=10m ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-and-test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify modules
+        run: go mod verify
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Unit tests
+        run: go test -race ./...
+
+  integration-test:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up OpenTofu
+        uses: opentofu/setup-opentofu@v1
+
+      - name: Integration tests
+        run: go test -tags=integration -timeout=10m ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,15 @@ jobs:
           tofu_wrapper: false
 
       - name: Integration tests
-        run: go test -tags=integration -timeout=10m ./...
+        id: integration
+        run: go test -tags=integration -timeout=10m -v ./...
+
+      - name: Dump container state on failure
+        if: failure() && steps.integration.outcome == 'failure'
+        run: |
+          echo "=== docker ps -a ==="
+          docker ps -a || true
+          for c in $(docker ps -aq --filter "label=openporch.managed=true"); do
+            echo "=== docker logs $c ==="
+            docker logs --tail=200 "$c" || true
+          done

--- a/examples/platform/modules/workload-local-docker/main.tf
+++ b/examples/platform/modules/workload-local-docker/main.tf
@@ -39,6 +39,12 @@ resource "docker_container" "this" {
     external = var.host_port
     ip       = "0.0.0.0"
   }
+  # Ensure host.docker.internal resolves from inside the container on Linux
+  # (Docker Desktop on macOS/Windows provides this automatically).
+  host {
+    host = "host.docker.internal"
+    ip   = "host-gateway"
+  }
   restart = "unless-stopped"
   labels {
     label = "openporch.managed"


### PR DESCRIPTION
## Summary
This PR introduces a GitHub Actions CI workflow to automate build, test, and verification processes for the Go project.

## Key Changes
- **Build and test job**: Runs on every push to main and pull requests
  - Checks out code and sets up Go environment from go.mod
  - Verifies Go modules integrity
  - Builds all packages
  - Runs go vet for code quality checks
  - Executes unit tests with race condition detection

- **Integration test job**: Dedicated job for integration tests
  - Sets up OpenTofu in addition to Go environment
  - Runs integration tests with 10-minute timeout
  - Uses build tags to distinguish integration tests from unit tests

## Implementation Details
- Both jobs run on ubuntu-latest for consistency
- Go version is dynamically read from go.mod file
- Module caching is enabled to improve workflow performance
- Integration tests are separated from unit tests using build tags, allowing them to run independently and with appropriate timeouts
- Race detector is enabled for unit tests to catch concurrency issues

https://claude.ai/code/session_016gJ9cPUFwqJgAFXKVvSdtB