### PR TITLE
Add get command to query deployment history

### DIFF
--- a/cmd/openporch/cmd_get.go
+++ b/cmd/openporch/cmd_get.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+func newGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get",
+		Short: "Read deployment history",
+	}
+	cmd.AddCommand(newGetDeploymentsCmd(), newGetDeploymentCmd())
+	return cmd
+}
+
+func newGetDeploymentsCmd() *cobra.Command {
+	var (
+		project   string
+		env       string
+		limit     int
+		output    string
+		stateRoot string
+	)
+	cmd := &cobra.Command{
+		Use:   "deployments",
+		Short: "List deployment history",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			d, err := db.Open(stateRoot)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+
+			rows, err := db.NewReader(d).ListDeployments(ctx, project, env, limit)
+			if err != nil {
+				return err
+			}
+
+			switch output {
+			case "json":
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(rows)
+			case "yaml":
+				enc := yaml.NewEncoder(os.Stdout)
+				enc.SetIndent(2)
+				return enc.Encode(rows)
+			default:
+				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+				fmt.Fprintln(w, "ID\tPROJECT\tENV\tSTATUS\tSTARTED_AT\tMODE")
+				for _, row := range rows {
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+						row.ID, row.Project, row.Env, row.Status, row.StartedAt, row.Mode)
+				}
+				return w.Flush()
+			}
+		},
+	}
+	cmd.Flags().StringVar(&project, "project", "", "filter by project")
+	cmd.Flags().StringVar(&env, "env", "", "filter by environment")
+	cmd.Flags().IntVar(&limit, "limit", 20, "maximum number of results")
+	cmd.Flags().StringVarP(&output, "output", "o", "table", "output format: table, yaml, json")
+	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
+		"directory under which openporch metadata lives")
+	return cmd
+}
+
+func newGetDeploymentCmd() *cobra.Command {
+	var (
+		output    string
+		stateRoot string
+	)
+	cmd := &cobra.Command{
+		Use:   "deployment <id>",
+		Short: "Get a single deployment record",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			d, err := db.Open(stateRoot)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+
+			det, err := db.NewReader(d).GetDeployment(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			if det == nil {
+				return fmt.Errorf("deployment %q not found", args[0])
+			}
+
+			switch output {
+			case "yaml":
+				fmt.Print(det.ManifestYAML)
+				return nil
+			case "json":
+				enc := json.NewEncoder(os.Stdout)
+				enc.SetIndent("", "  ")
+				return enc.Encode(det)
+			default:
+				fmt.Printf("ID:         %s\n", det.ID)
+				fmt.Printf("Project:    %s\n", det.Project)
+				fmt.Printf("Env:        %s\n", det.Env)
+				fmt.Printf("EnvType:    %s\n", det.EnvType)
+				fmt.Printf("Status:     %s\n", det.Status)
+				fmt.Printf("Mode:       %s\n", det.Mode)
+				fmt.Printf("StartedAt:  %s\n", det.StartedAt)
+				if det.FinishedAt != "" {
+					fmt.Printf("FinishedAt: %s\n", det.FinishedAt)
+				}
+				if len(det.Resources) > 0 {
+					fmt.Println("\nResources:")
+					w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+					fmt.Fprintln(w, "  KEY\tTYPE\tSTATUS\tRUNNER\tLOG")
+					for _, res := range det.Resources {
+						fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n",
+							res.ResourceKey, res.Type, res.Status, res.RunnerID, res.LogPath)
+					}
+					w.Flush()
+				}
+				return nil
+			}
+		},
+	}
+	cmd.Flags().StringVarP(&output, "output", "o", "", "output format: yaml, json (default: human summary)")
+	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
+		"directory under which openporch metadata lives")
+	return cmd
+}

--- a/cmd/openporch/cmd_get.go
+++ b/cmd/openporch/cmd_get.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -46,17 +46,18 @@ func newGetDeploymentsCmd() *cobra.Command {
 				return err
 			}
 
+			out := cmd.OutOrStdout()
 			switch output {
 			case "json":
-				enc := json.NewEncoder(os.Stdout)
+				enc := json.NewEncoder(out)
 				enc.SetIndent("", "  ")
 				return enc.Encode(rows)
 			case "yaml":
-				enc := yaml.NewEncoder(os.Stdout)
+				enc := yaml.NewEncoder(out)
 				enc.SetIndent(2)
 				return enc.Encode(rows)
 			default:
-				w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+				w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 				fmt.Fprintln(w, "ID\tPROJECT\tENV\tSTATUS\tSTARTED_AT\tMODE")
 				for _, row := range rows {
 					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
@@ -100,35 +101,17 @@ func newGetDeploymentCmd() *cobra.Command {
 				return fmt.Errorf("deployment %q not found", args[0])
 			}
 
+			out := cmd.OutOrStdout()
 			switch output {
 			case "yaml":
-				fmt.Print(det.ManifestYAML)
+				fmt.Fprint(out, det.ManifestYAML)
 				return nil
 			case "json":
-				enc := json.NewEncoder(os.Stdout)
+				enc := json.NewEncoder(out)
 				enc.SetIndent("", "  ")
 				return enc.Encode(det)
 			default:
-				fmt.Printf("ID:         %s\n", det.ID)
-				fmt.Printf("Project:    %s\n", det.Project)
-				fmt.Printf("Env:        %s\n", det.Env)
-				fmt.Printf("EnvType:    %s\n", det.EnvType)
-				fmt.Printf("Status:     %s\n", det.Status)
-				fmt.Printf("Mode:       %s\n", det.Mode)
-				fmt.Printf("StartedAt:  %s\n", det.StartedAt)
-				if det.FinishedAt != "" {
-					fmt.Printf("FinishedAt: %s\n", det.FinishedAt)
-				}
-				if len(det.Resources) > 0 {
-					fmt.Println("\nResources:")
-					w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-					fmt.Fprintln(w, "  KEY\tTYPE\tSTATUS\tRUNNER\tLOG")
-					for _, res := range det.Resources {
-						fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n",
-							res.ResourceKey, res.Type, res.Status, res.RunnerID, res.LogPath)
-					}
-					w.Flush()
-				}
+				printDeploymentSummary(out, det)
 				return nil
 			}
 		},
@@ -137,4 +120,27 @@ func newGetDeploymentCmd() *cobra.Command {
 	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
 		"directory under which openporch metadata lives")
 	return cmd
+}
+
+func printDeploymentSummary(out io.Writer, det *db.DeploymentDetail) {
+	fmt.Fprintf(out, "ID:         %s\n", det.ID)
+	fmt.Fprintf(out, "Project:    %s\n", det.Project)
+	fmt.Fprintf(out, "Env:        %s\n", det.Env)
+	fmt.Fprintf(out, "EnvType:    %s\n", det.EnvType)
+	fmt.Fprintf(out, "Status:     %s\n", det.Status)
+	fmt.Fprintf(out, "Mode:       %s\n", det.Mode)
+	fmt.Fprintf(out, "StartedAt:  %s\n", det.StartedAt)
+	if det.FinishedAt != "" {
+		fmt.Fprintf(out, "FinishedAt: %s\n", det.FinishedAt)
+	}
+	if len(det.Resources) > 0 {
+		fmt.Fprintln(out, "\nResources:")
+		w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "  KEY\tTYPE\tSTATUS\tRUNNER\tLOG")
+		for _, res := range det.Resources {
+			fmt.Fprintf(w, "  %s\t%s\t%s\t%s\t%s\n",
+				res.ResourceKey, res.Type, res.Status, res.RunnerID, res.LogPath)
+		}
+		w.Flush()
+	}
 }

--- a/cmd/openporch/cmd_get_test.go
+++ b/cmd/openporch/cmd_get_test.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+// runGet executes "openporch get <args...> --state-root <stateRoot>" and
+// returns captured stdout plus any error.
+func runGet(t *testing.T, stateRoot string, args ...string) (string, error) {
+	t.Helper()
+	root := &cobra.Command{Use: "openporch", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(newGetCmd())
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	allArgs := append([]string{"get"}, args...)
+	allArgs = append(allArgs, "--state-root", stateRoot)
+	root.SetArgs(allArgs)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// mustSeedDB seeds stateRoot with one complete deployment (started + one
+// resource + finished) and returns the deployment ID and manifest YAML.
+func mustSeedDB(t *testing.T, stateRoot string) (depID, manifestYAML string) {
+	t.Helper()
+	d, err := db.Open(stateRoot)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	ctx := context.Background()
+	rec := db.NewRecorder(d)
+	depID = "dep-abc123"
+	manifestYAML = "kind: Manifest\nmetadata:\n  project: myproj\n"
+	started := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+
+	if err := rec.StartDeployment(ctx, deploy.DeploymentRecord{
+		ID: depID, Project: "myproj", Env: "dev", EnvType: "local",
+		Mode: "deploy", StartedAt: started,
+		ManifestYAML: manifestYAML, GraphJSON: `{"nodes":[]}`,
+	}); err != nil {
+		t.Fatalf("StartDeployment: %v", err)
+	}
+	if err := rec.RecordResource(ctx, depID, deploy.ResourceRecord{
+		ResourceKey: "service|default|api", Type: "service", Class: "default",
+		ID: "api", ModuleID: "mod-svc", RunnerID: "local-tofu",
+		Status: "applied", LogPath: "/tmp/api.log",
+	}); err != nil {
+		t.Fatalf("RecordResource: %v", err)
+	}
+	if err := rec.FinishDeployment(ctx, depID, "succeeded", started.Add(2*time.Minute)); err != nil {
+		t.Fatalf("FinishDeployment: %v", err)
+	}
+	return depID, manifestYAML
+}
+
+// ---------------------------------------------------------------------------
+// get deployments
+// ---------------------------------------------------------------------------
+
+func TestGetDeployments_EmptyDB(t *testing.T) {
+	out, err := runGet(t, t.TempDir(), "deployments")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// header must appear, no data rows
+	if !strings.Contains(out, "ID") || !strings.Contains(out, "PROJECT") {
+		t.Errorf("expected table header in output, got:\n%s", out)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line (header only), got %d:\n%s", len(lines), out)
+	}
+}
+
+func TestGetDeployments_ListsDeployment(t *testing.T) {
+	root := t.TempDir()
+	depID, _ := mustSeedDB(t, root)
+
+	out, err := runGet(t, root, "deployments")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, depID) {
+		t.Errorf("deployment ID %q not found in output:\n%s", depID, out)
+	}
+	if !strings.Contains(out, "myproj") {
+		t.Errorf("project not found in output:\n%s", out)
+	}
+	if !strings.Contains(out, "succeeded") {
+		t.Errorf("status not found in output:\n%s", out)
+	}
+}
+
+func TestGetDeployments_ProjectFilter(t *testing.T) {
+	root := t.TempDir()
+	mustSeedDB(t, root)
+
+	// Seed a second deployment under a different project.
+	d, _ := db.Open(root)
+	rec := db.NewRecorder(d)
+	rec.StartDeployment(context.Background(), deploy.DeploymentRecord{
+		ID: "dep-other", Project: "other", Env: "dev", EnvType: "local",
+		Mode: "deploy", StartedAt: time.Now().UTC(),
+		ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	})
+	d.Close()
+
+	out, err := runGet(t, root, "deployments", "--project", "myproj")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "dep-abc123") {
+		t.Errorf("myproj deployment missing from output:\n%s", out)
+	}
+	if strings.Contains(out, "dep-other") {
+		t.Errorf("other project deployment should be filtered out:\n%s", out)
+	}
+}
+
+func TestGetDeployments_NonexistentProject(t *testing.T) {
+	root := t.TempDir()
+	mustSeedDB(t, root)
+
+	out, err := runGet(t, root, "deployments", "--project", "nonexistent")
+	if err != nil {
+		t.Fatalf("expected no error for nonexistent project, got: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected header only (1 line), got %d lines:\n%s", len(lines), out)
+	}
+}
+
+func TestGetDeployments_JSONOutput(t *testing.T) {
+	root := t.TempDir()
+	depID, _ := mustSeedDB(t, root)
+
+	out, err := runGet(t, root, "deployments", "-o", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var rows []db.DeploymentRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].ID != depID {
+		t.Errorf("ID = %q, want %q", rows[0].ID, depID)
+	}
+	if rows[0].Project != "myproj" {
+		t.Errorf("Project = %q, want myproj", rows[0].Project)
+	}
+	if rows[0].Status != "succeeded" {
+		t.Errorf("Status = %q, want succeeded", rows[0].Status)
+	}
+}
+
+func TestGetDeployments_YAMLOutput(t *testing.T) {
+	root := t.TempDir()
+	depID, _ := mustSeedDB(t, root)
+
+	out, err := runGet(t, root, "deployments", "-o", "yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var rows []db.DeploymentRow
+	if err := yaml.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not valid YAML: %v\n%s", err, out)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].ID != depID {
+		t.Errorf("ID = %q, want %q", rows[0].ID, depID)
+	}
+}
+
+func TestGetDeployments_Limit(t *testing.T) {
+	root := t.TempDir()
+	d, _ := db.Open(root)
+	rec := db.NewRecorder(d)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for i := range 5 {
+		rec.StartDeployment(context.Background(), deploy.DeploymentRecord{
+			ID: "lim-" + string(rune('a'+i)), Project: "p", Env: "e", EnvType: "local",
+			Mode: "deploy", StartedAt: base.Add(time.Duration(i) * time.Hour),
+			ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+		})
+	}
+	d.Close()
+
+	out, err := runGet(t, root, "deployments", "--limit", "2", "-o", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var rows []db.DeploymentRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("expected 2 rows with --limit 2, got %d", len(rows))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get deployment <id>
+// ---------------------------------------------------------------------------
+
+func TestGetDeployment_NotFound(t *testing.T) {
+	_, err := runGet(t, t.TempDir(), "deployment", "no-such-id")
+	if err == nil {
+		t.Error("expected error for nonexistent deployment ID, got nil")
+	}
+}
+
+func TestGetDeployment_DefaultSummary(t *testing.T) {
+	root := t.TempDir()
+	depID, _ := mustSeedDB(t, root)
+
+	out, err := runGet(t, root, "deployment", depID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"ID:", "Project:", "myproj", "Status:", "succeeded", "Mode:", "deploy"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+	// Resources section should appear (we seeded one resource)
+	if !strings.Contains(out, "Resources:") {
+		t.Errorf("expected Resources section:\n%s", out)
+	}
+	if !strings.Contains(out, "service|default|api") {
+		t.Errorf("expected resource key in output:\n%s", out)
+	}
+}
+
+func TestGetDeployment_YAMLRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	depID, manifestYAML := mustSeedDB(t, root)
+
+	out, err := runGet(t, root, "deployment", depID, "-o", "yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out != manifestYAML {
+		t.Errorf("-o yaml output does not round-trip manifest byte-for-byte\ngot:  %q\nwant: %q", out, manifestYAML)
+	}
+}
+
+func TestGetDeployment_JSONOutput(t *testing.T) {
+	root := t.TempDir()
+	depID, _ := mustSeedDB(t, root)
+
+	out, err := runGet(t, root, "deployment", depID, "-o", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var det db.DeploymentDetail
+	if err := json.Unmarshal([]byte(out), &det); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if det.ID != depID {
+		t.Errorf("ID = %q, want %q", det.ID, depID)
+	}
+	if det.Project != "myproj" {
+		t.Errorf("Project = %q, want myproj", det.Project)
+	}
+	if det.ManifestYAML == "" {
+		t.Error("ManifestYAML should be non-empty in JSON output")
+	}
+	if len(det.Resources) != 1 {
+		t.Errorf("expected 1 resource in JSON output, got %d", len(det.Resources))
+	}
+	if det.Resources[0].RunnerID != "local-tofu" {
+		t.Errorf("Resources[0].RunnerID = %q, want local-tofu", det.Resources[0].RunnerID)
+	}
+}

--- a/cmd/openporch/main.go
+++ b/cmd/openporch/main.go
@@ -18,7 +18,7 @@ platform-engineer-authored library of OpenTofu modules and rules, picks the
 right module for each (project, env, env_type), and runs OpenTofu to converge.`,
 		SilenceUsage: true,
 	}
-	root.AddCommand(newDeployCmd(), newDestroyCmd(), newValidateCmd(), newVersionCmd())
+	root.AddCommand(newDeployCmd(), newDestroyCmd(), newValidateCmd(), newGetCmd(), newVersionCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/store/db/reader.go
+++ b/internal/store/db/reader.go
@@ -1,0 +1,133 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// DeploymentRow is a single row from the deployments table.
+type DeploymentRow struct {
+	ID         string `json:"id" yaml:"id"`
+	Project    string `json:"project" yaml:"project"`
+	Env        string `json:"env" yaml:"env"`
+	EnvType    string `json:"env_type" yaml:"env_type"`
+	Status     string `json:"status" yaml:"status"`
+	StartedAt  string `json:"started_at" yaml:"started_at"`
+	FinishedAt string `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
+	Mode       string `json:"mode" yaml:"mode"`
+}
+
+// ResourceRow is a single row from the deployment_resources table.
+type ResourceRow struct {
+	ResourceKey string `json:"resource_key" yaml:"resource_key"`
+	Type        string `json:"type" yaml:"type"`
+	Class       string `json:"class" yaml:"class"`
+	ID          string `json:"id" yaml:"id"`
+	ModuleID    string `json:"module_id" yaml:"module_id"`
+	RunnerID    string `json:"runner_id" yaml:"runner_id"`
+	Status      string `json:"status" yaml:"status"`
+	OutputsJSON string `json:"outputs_json,omitempty" yaml:"outputs_json,omitempty"`
+	LogPath     string `json:"log_path" yaml:"log_path"`
+}
+
+// DeploymentDetail is a full deployment record including manifest and resources.
+type DeploymentDetail struct {
+	ID           string        `json:"id" yaml:"id"`
+	Project      string        `json:"project" yaml:"project"`
+	Env          string        `json:"env" yaml:"env"`
+	EnvType      string        `json:"env_type" yaml:"env_type"`
+	Status       string        `json:"status" yaml:"status"`
+	StartedAt    string        `json:"started_at" yaml:"started_at"`
+	FinishedAt   string        `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
+	Mode         string        `json:"mode" yaml:"mode"`
+	ManifestYAML string        `json:"manifest_yaml" yaml:"manifest_yaml"`
+	Resources    []ResourceRow `json:"resources" yaml:"resources"`
+}
+
+// Reader queries the deployment history stored in DB.
+type Reader struct {
+	db *DB
+}
+
+// NewReader returns a Reader backed by the given DB.
+func NewReader(db *DB) *Reader {
+	return &Reader{db: db}
+}
+
+// ListDeployments returns deployments filtered by project and env (empty = all),
+// ordered by started_at descending, capped at limit rows.
+func (r *Reader) ListDeployments(ctx context.Context, project, env string, limit int) ([]DeploymentRow, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT id, project, env, env_type, status, started_at, COALESCE(finished_at, ''), mode
+		 FROM deployments
+		 WHERE (? = '' OR project = ?) AND (? = '' OR env = ?)
+		 ORDER BY started_at DESC
+		 LIMIT ?`,
+		project, project, env, env, limit)
+	if err != nil {
+		return nil, fmt.Errorf("db: list deployments: %w", err)
+	}
+	defer rows.Close()
+	var out []DeploymentRow
+	for rows.Next() {
+		var d DeploymentRow
+		if err := rows.Scan(&d.ID, &d.Project, &d.Env, &d.EnvType, &d.Status, &d.StartedAt, &d.FinishedAt, &d.Mode); err != nil {
+			return nil, fmt.Errorf("db: scan deployment row: %w", err)
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: list deployments: %w", err)
+	}
+	if out == nil {
+		out = []DeploymentRow{}
+	}
+	return out, nil
+}
+
+// GetDeployment returns the full record for a single deployment, or nil if not found.
+func (r *Reader) GetDeployment(ctx context.Context, id string) (*DeploymentDetail, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id, project, env, env_type, status, started_at, COALESCE(finished_at, ''), mode
+		 FROM deployments WHERE id = ?`, id)
+	var d DeploymentDetail
+	err := row.Scan(&d.ID, &d.Project, &d.Env, &d.EnvType, &d.Status, &d.StartedAt, &d.FinishedAt, &d.Mode)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: get deployment: %w", err)
+	}
+
+	mRow := r.db.QueryRowContext(ctx,
+		`SELECT manifest_yaml FROM deployment_manifest WHERE deployment_id = ?`, id)
+	if err := mRow.Scan(&d.ManifestYAML); err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("db: get deployment manifest: %w", err)
+	}
+
+	resRows, err := r.db.QueryContext(ctx,
+		`SELECT resource_key, type, class, id, module_id, runner_id, status,
+		        COALESCE(outputs_json, ''), log_path
+		 FROM deployment_resources WHERE deployment_id = ?
+		 ORDER BY resource_key`, id)
+	if err != nil {
+		return nil, fmt.Errorf("db: get deployment resources: %w", err)
+	}
+	defer resRows.Close()
+	for resRows.Next() {
+		var res ResourceRow
+		if err := resRows.Scan(&res.ResourceKey, &res.Type, &res.Class, &res.ID,
+			&res.ModuleID, &res.RunnerID, &res.Status, &res.OutputsJSON, &res.LogPath); err != nil {
+			return nil, fmt.Errorf("db: scan resource row: %w", err)
+		}
+		d.Resources = append(d.Resources, res)
+	}
+	if err := resRows.Err(); err != nil {
+		return nil, fmt.Errorf("db: get deployment resources: %w", err)
+	}
+	if d.Resources == nil {
+		d.Resources = []ResourceRow{}
+	}
+	return &d, nil
+}

--- a/internal/store/db/reader_test.go
+++ b/internal/store/db/reader_test.go
@@ -1,0 +1,322 @@
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/krbrudeli/openporch/internal/deploy"
+)
+
+// mustSeed inserts one deployment (and optionally marks it finished) plus any
+// supplied resources. All fatal errors are surfaced via t.Fatalf.
+func mustSeed(t *testing.T, rec *SQLiteRecorder, d deploy.DeploymentRecord, finished bool, resources []deploy.ResourceRecord) {
+	t.Helper()
+	ctx := context.Background()
+	if err := rec.StartDeployment(ctx, d); err != nil {
+		t.Fatalf("StartDeployment %s: %v", d.ID, err)
+	}
+	for _, r := range resources {
+		if err := rec.RecordResource(ctx, d.ID, r); err != nil {
+			t.Fatalf("RecordResource %s/%s: %v", d.ID, r.ResourceKey, err)
+		}
+	}
+	if finished {
+		if err := rec.FinishDeployment(ctx, d.ID, "succeeded", d.StartedAt.Add(time.Minute)); err != nil {
+			t.Fatalf("FinishDeployment %s: %v", d.ID, err)
+		}
+	}
+}
+
+func openTestDB(t *testing.T) (*DB, *SQLiteRecorder, *Reader) {
+	t.Helper()
+	d, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	rec := NewRecorder(d)
+	rdr := NewReader(d)
+	return d, rec, rdr
+}
+
+// ---------------------------------------------------------------------------
+// ListDeployments
+// ---------------------------------------------------------------------------
+
+func TestListDeployments_Empty(t *testing.T) {
+	_, _, rdr := openTestDB(t)
+	rows, err := rdr.ListDeployments(context.Background(), "", "", 20)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected empty slice, got %d rows", len(rows))
+	}
+}
+
+func TestListDeployments_Order(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for i, id := range []string{"dep-a", "dep-b", "dep-c"} {
+		mustSeed(t, rec, deploy.DeploymentRecord{
+			ID: id, Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+			StartedAt:    base.Add(time.Duration(i) * time.Hour),
+			ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+		}, false, nil)
+	}
+
+	rows, err := rdr.ListDeployments(context.Background(), "", "", 20)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	// started_at DESC means dep-c (latest) first
+	wantOrder := []string{"dep-c", "dep-b", "dep-a"}
+	for i, want := range wantOrder {
+		if rows[i].ID != want {
+			t.Errorf("rows[%d].ID = %q, want %q", i, rows[i].ID, want)
+		}
+	}
+}
+
+func TestListDeployments_ProjectFilter(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "d1", Project: "alpha", Env: "dev", EnvType: "local", Mode: "deploy",
+		StartedAt: base, ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "d2", Project: "beta", Env: "dev", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(time.Minute), ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+
+	rows, err := rdr.ListDeployments(context.Background(), "alpha", "", 20)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != "d1" {
+		t.Errorf("got %v, want [{ID:d1}]", rows)
+	}
+}
+
+func TestListDeployments_EnvFilter(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "e1", Project: "p", Env: "staging", EnvType: "local", Mode: "deploy",
+		StartedAt: base, ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "e2", Project: "p", Env: "prod", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(time.Minute), ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+
+	rows, err := rdr.ListDeployments(context.Background(), "", "prod", 20)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != "e2" {
+		t.Errorf("got %v, want [{ID:e2}]", rows)
+	}
+}
+
+func TestListDeployments_NonexistentFilter(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "x1", Project: "real", Env: "dev", EnvType: "local", Mode: "deploy",
+		StartedAt:    time.Now().UTC(),
+		ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+
+	rows, err := rdr.ListDeployments(context.Background(), "nonexistent", "", 20)
+	if err != nil {
+		t.Fatalf("ListDeployments with nonexistent project: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected empty, got %d rows", len(rows))
+	}
+}
+
+func TestListDeployments_Limit(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	for i := range 5 {
+		mustSeed(t, rec, deploy.DeploymentRecord{
+			ID: "lim-" + string(rune('a'+i)), Project: "p", Env: "e", EnvType: "local",
+			Mode: "deploy", StartedAt: base.Add(time.Duration(i) * time.Hour),
+			ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+		}, false, nil)
+	}
+
+	rows, err := rdr.ListDeployments(context.Background(), "", "", 3)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Errorf("got %d rows with limit=3, want 3", len(rows))
+	}
+}
+
+func TestListDeployments_CombinedFilter(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "c1", Project: "p", Env: "dev", EnvType: "local", Mode: "deploy",
+		StartedAt: base, ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "c2", Project: "p", Env: "prod", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(time.Minute), ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "c3", Project: "q", Env: "dev", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(2 * time.Minute), ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+
+	rows, err := rdr.ListDeployments(context.Background(), "p", "dev", 20)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != "c1" {
+		t.Errorf("got %v, want [{ID:c1}]", rows)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetDeployment
+// ---------------------------------------------------------------------------
+
+func TestGetDeployment_NotFound(t *testing.T) {
+	_, _, rdr := openTestDB(t)
+	det, err := rdr.GetDeployment(context.Background(), "no-such-id")
+	if err != nil {
+		t.Fatalf("GetDeployment: unexpected error: %v", err)
+	}
+	if det != nil {
+		t.Errorf("expected nil, got %+v", det)
+	}
+}
+
+func TestGetDeployment_FullRecord(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	ctx := context.Background()
+	started := time.Date(2026, 3, 15, 9, 0, 0, 0, time.UTC)
+	manifest := "kind: Manifest\nmetadata:\n  project: myproj\n"
+
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "full-1", Project: "myproj", Env: "staging", EnvType: "cloud",
+		Mode: "deploy", StartedAt: started,
+		ManifestYAML: manifest, GraphJSON: `{"nodes":[]}`,
+	}, true, []deploy.ResourceRecord{
+		{
+			ResourceKey: "service|default|api", Type: "service", Class: "default",
+			ID: "api", ModuleID: "mod-svc", RunnerID: "local-tofu",
+			Status: "applied", OutputsJSON: `{"url":"http://x"}`, LogPath: "/tmp/api.log",
+		},
+		{
+			ResourceKey: "postgres|default|db", Type: "postgres", Class: "default",
+			ID: "db", ModuleID: "mod-pg", RunnerID: "local-tofu",
+			Status: "applied", LogPath: "/tmp/db.log",
+		},
+	})
+
+	det, err := rdr.GetDeployment(ctx, "full-1")
+	if err != nil {
+		t.Fatalf("GetDeployment: %v", err)
+	}
+	if det == nil {
+		t.Fatal("expected non-nil detail")
+	}
+
+	if det.ID != "full-1" {
+		t.Errorf("ID = %q, want full-1", det.ID)
+	}
+	if det.Project != "myproj" {
+		t.Errorf("Project = %q, want myproj", det.Project)
+	}
+	if det.Env != "staging" {
+		t.Errorf("Env = %q, want staging", det.Env)
+	}
+	if det.EnvType != "cloud" {
+		t.Errorf("EnvType = %q, want cloud", det.EnvType)
+	}
+	if det.Status != "succeeded" {
+		t.Errorf("Status = %q, want succeeded", det.Status)
+	}
+	if det.Mode != "deploy" {
+		t.Errorf("Mode = %q, want deploy", det.Mode)
+	}
+	if det.ManifestYAML != manifest {
+		t.Errorf("ManifestYAML = %q, want %q", det.ManifestYAML, manifest)
+	}
+	if det.FinishedAt == "" {
+		t.Error("FinishedAt should be set after FinishDeployment")
+	}
+	if len(det.Resources) != 2 {
+		t.Fatalf("len(Resources) = %d, want 2", len(det.Resources))
+	}
+	// resources are ordered by resource_key
+	r0 := det.Resources[0]
+	if r0.ResourceKey != "postgres|default|db" {
+		t.Errorf("Resources[0].ResourceKey = %q, want postgres|default|db", r0.ResourceKey)
+	}
+	r1 := det.Resources[1]
+	if r1.ResourceKey != "service|default|api" {
+		t.Errorf("Resources[1].ResourceKey = %q, want service|default|api", r1.ResourceKey)
+	}
+	if r1.RunnerID != "local-tofu" {
+		t.Errorf("Resources[1].RunnerID = %q, want local-tofu", r1.RunnerID)
+	}
+	if r1.OutputsJSON != `{"url":"http://x"}` {
+		t.Errorf("Resources[1].OutputsJSON = %q, want {\"url\":\"http://x\"}", r1.OutputsJSON)
+	}
+}
+
+func TestGetDeployment_NoResources(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "no-res", Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt:    time.Now().UTC(),
+		ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false, nil)
+
+	det, err := rdr.GetDeployment(context.Background(), "no-res")
+	if err != nil {
+		t.Fatalf("GetDeployment: %v", err)
+	}
+	if det == nil {
+		t.Fatal("expected non-nil")
+	}
+	if len(det.Resources) != 0 {
+		t.Errorf("expected no resources, got %d", len(det.Resources))
+	}
+}
+
+func TestGetDeployment_FinishedAtEmpty(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "running-1", Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt:    time.Now().UTC(),
+		ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, false /* not finished */, nil)
+
+	det, err := rdr.GetDeployment(context.Background(), "running-1")
+	if err != nil {
+		t.Fatalf("GetDeployment: %v", err)
+	}
+	if det.FinishedAt != "" {
+		t.Errorf("FinishedAt = %q, want empty for in-progress deployment", det.FinishedAt)
+	}
+	if det.Status != "running" {
+		t.Errorf("Status = %q, want running", det.Status)
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds a new `get` command to the OpenPorch CLI that allows users to query and view deployment history from the database. The command supports listing multiple deployments with filtering and retrieving detailed information about individual deployments.

## Key Changes
- **New CLI command structure**: Added `cmd/openporch/cmd_get.go` with two subcommands:
  - `get deployments`: Lists deployment history with optional filtering by project/environment and configurable output formats (table, JSON, YAML)
  - `get deployment <id>`: Retrieves detailed information about a single deployment including manifest and resource details
  
- **New database reader layer**: Added `internal/store/db/reader.go` with:
  - `DeploymentRow`: Struct for listing deployments with basic metadata
  - `ResourceRow`: Struct for deployment resource details
  - `DeploymentDetail`: Struct for complete deployment information including manifest and resources
  - `Reader`: Query interface with `ListDeployments()` and `GetDeployment()` methods

- **CLI integration**: Updated `cmd/openporch/main.go` to register the new `get` command in the root command

## Notable Implementation Details
- The `get deployments` command supports flexible filtering with empty strings matching all values
- Results are ordered by `started_at` descending with a configurable limit (default 20)
- Multiple output formats are supported: human-readable table (default), JSON, and YAML
- The `get deployment` command displays a formatted summary by default, with optional JSON/YAML output
- Resources are displayed in a tabular format showing key, type, status, runner, and log path
- Proper error handling for missing deployments and database operations
- Uses context for database operations and properly closes resources

https://claude.ai/code/session_01HAzHkpiXth3iTAGiiVCoQa