### PR TITLE
Add testing playbook and development guidelines

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: testing
+description: Playbook for writing unit, CLI, and integration tests in the openporch repo. Invoke when adding new tests, debugging flaky tests, or reviewing test changes. Covers fakes, golden files, testscript, and the integration-test build-tag pattern.
+---
+
+# Testing playbook
+
+Companion to the rules in `CLAUDE.md`. The rules in `CLAUDE.md` say *what
+must be true* of the test suite; this skill says *how to write a test that
+satisfies them*.
+
+Read `CLAUDE.md` first if you haven't. Then pick the section below that
+matches the layer you're testing.
+
+## Choosing a layer
+
+| What you're changing                                  | Test layer                                |
+|-------------------------------------------------------|-------------------------------------------|
+| Pure logic in `internal/<pkg>/` or `api/v1alpha1/`    | Unit test in the same package            |
+| `cmd/openporch/` flag, exit code, or output           | testscript (`cmd/openporch/testdata/*.txtar`) |
+| Real `tofu` / Docker behavior                         | Integration test (build tag `integration`)|
+
+If a change spans layers, add tests at every layer it crosses. Don't rely on
+the integration test alone to catch a unit-level regression — its feedback
+loop is too slow.
+
+## Unit tests
+
+Templates and conventions:
+
+- File name: `<thing>_test.go`, same package as `<thing>.go`. Use the
+  `<pkg>_test` (black-box) variant only when you genuinely want to test the
+  public API surface (most existing tests use white-box; that's fine).
+- Top of every test: `t.Parallel()`.
+- Table-driven shape (use when ≥ 3 cases of the same shape):
+
+  ```go
+  func TestModule_specificity(t *testing.T) {
+      t.Parallel()
+      tests := []struct {
+          name string
+          ctx  Context
+          want string
+      }{
+          {"catchall", Context{ResourceType: "postgres"}, "default"},
+          // ...
+      }
+      for _, tc := range tests {
+          tc := tc
+          t.Run(tc.name, func(t *testing.T) {
+              t.Parallel()
+              got, err := Module(rules, tc.ctx)
+              if err != nil {
+                  t.Fatalf("Module: %v", err)
+              }
+              if diff := cmp.Diff(tc.want, got); diff != "" {
+                  t.Errorf("Module() mismatch (-want +got):\n%s", diff)
+              }
+          })
+      }
+  }
+  ```
+
+- `t.Fatalf` for setup/precondition failures (further assertions would be
+  meaningless). `t.Errorf` for independent assertions where you want the
+  rest of the test to keep going.
+- Filesystem state: `t.TempDir()` only. Helpers that take `*testing.T` start
+  with `t.Helper()`.
+- Env vars: `t.Setenv` (which forces serial execution within that test —
+  acceptable trade-off but call out the lack of `t.Parallel`).
+
+### Fakes vs real implementations
+
+Prefer in-memory fakes for unit tests; reserve real implementations
+(`store.FS`, `runner.LocalTofu`) for integration tests.
+
+If a fake doesn't exist for an interface you're testing against, add one
+under `internal/<pkg>/<pkg>test/` (e.g. `storetest.Fake`, `runnertest.Recording`).
+Keep the fake minimal: just enough to satisfy the interface and let the test
+assert against recorded calls.
+
+A fake should:
+
+1. Implement the full interface so calling code compiles against either.
+2. Record calls in fields the test can read (`Calls []ApplyCall`).
+3. Allow stubbed return values via fields (`ApplyErr error`).
+
+### Diffs over equality
+
+Use `github.com/google/go-cmp/cmp` for any struct or slice comparison larger
+than two fields. Write the diff message as `"X mismatch (-want +got):\n%s"`
+so the agent reading the failure can immediately see which field changed.
+
+For unexported fields, use `cmp.AllowUnexported(MyType{})` rather than
+exporting fields just for tests.
+
+## CLI tests (testscript)
+
+`cmd/openporch/` is a public surface. Cover it with `rsc.io/script/scripttest`:
+
+```go
+// cmd/openporch/cli_test.go
+//go:build !integration
+
+package main
+
+import (
+    "os"
+    "testing"
+
+    "rsc.io/script/scripttest"
+)
+
+func TestMain(m *testing.M) {
+    os.Exit(scripttest.RunMain(m, map[string]func() int{
+        "openporch": run, // run is your main-equivalent that returns an int exit code
+    }))
+}
+
+func TestCLI(t *testing.T) {
+    t.Parallel()
+    scripttest.Run(t, scripttest.DefaultCmds(), nil, "testdata/*.txtar")
+}
+```
+
+Each `.txtar` file is a self-contained scenario:
+
+```
+# validate accepts a well-formed manifest
+exec openporch validate manifest.yaml --platform platform/
+stdout 'manifest valid'
+! stderr .
+
+-- manifest.yaml --
+apiVersion: openporch/v1alpha1
+kind: Application
+...
+
+-- platform/modules.yaml --
+...
+```
+
+Why testscript: failures point at a specific line in a text file the agent
+can edit directly, and the scenario reads top-to-bottom like a shell session.
+Far more debuggable than building a `cobra.Command` by hand inside a `_test.go`.
+
+## Golden files for generated text
+
+For anything that produces text we care about byte-for-byte (rendered HCL in
+`internal/tofu`, JSON output, error messages), use golden files:
+
+```go
+func TestRender_smoke(t *testing.T) {
+    t.Parallel()
+    got, err := Render(plan)
+    if err != nil {
+        t.Fatalf("Render: %v", err)
+    }
+    goldenPath := filepath.Join("testdata", "render_smoke.golden.hcl")
+    if *update {
+        if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+            t.Fatal(err)
+        }
+    }
+    want, err := os.ReadFile(goldenPath)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if diff := cmp.Diff(string(want), got); diff != "" {
+        t.Errorf("rendered output mismatch (-want +got):\n%s", diff)
+    }
+}
+
+var update = flag.Bool("update", false, "update golden files")
+```
+
+Regenerate with `go test ./internal/tofu -update`. Commit the golden file.
+Reviewers diff the golden alongside the code change — that's the point.
+
+Don't combine "golden file" with "substring assertion": the golden file is
+the test. If a substring is what you actually care about (e.g. "the rendered
+output names the user-supplied image"), that's a separate, named test.
+
+## Integration tests
+
+Location: same package as the code, file `<feature>_integration_test.go`,
+build tag `integration`. Run with:
+
+```
+go test -tags=integration -timeout=5m ./...
+```
+
+Skeleton (cribbed from `internal/deploy/integration_test.go`):
+
+```go
+//go:build integration
+
+package deploy_test
+
+import (
+    "context"
+    "os"
+    "os/exec"
+    "testing"
+    "time"
+)
+
+func requireDocker(t *testing.T) {
+    t.Helper()
+    if err := exec.Command("docker", "version").Run(); err != nil {
+        if os.Getenv("CI") == "true" {
+            t.Fatalf("docker required in CI: %v", err)
+        }
+        t.Skipf("docker not available locally: %v", err)
+    }
+}
+
+func TestDeploy_endToEnd(t *testing.T) {
+    requireDocker(t)
+    // Do NOT t.Parallel() integration tests that bind host resources.
+
+    ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+    defer cancel()
+
+    stateRoot := t.TempDir()
+    // ... build manifest, override host_port to a non-default value,
+    //     wire store.FS{Root: stateRoot} + runner.LocalTofu{...}.
+
+    t.Cleanup(func() {
+        // Always tear down. Use a fresh, short context so cleanup runs even
+        // if the test's main ctx was cancelled.
+        cleanupCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+        defer cancel()
+        _ = deploy.Destroy(cleanupCtx, opts)
+    })
+
+    if err := deploy.Run(ctx, opts); err != nil {
+        t.Fatalf("Run: %v", err)
+    }
+    // Assert against the real outside world (HTTP probe, docker ps, ...).
+}
+```
+
+Critical points:
+
+- **CI-vs-local skip asymmetry.** `t.Skipf` is fine on a developer's laptop
+  without Docker. In CI it must `t.Fatalf` — silent skips are how broken
+  integration tests stay green for weeks. The `requireDocker` helper above
+  encodes this; copy it for `tofu` and any future prereq.
+- **Non-default ports/names.** Pick something unlikely to collide with a
+  developer's running stack. `host_port: 18080` and `host_port: 15433` in
+  `internal/deploy/integration_test.go` are the existing convention.
+- **Teardown uses a fresh context.** If the main `ctx` was cancelled or hit
+  its timeout, you still need `t.Cleanup` to actually run `destroy`.
+- **No `t.Parallel()` for tests that bind ports** or share a Docker daemon
+  namespace. Multiple integration tests should serialize unless they pick
+  disjoint ports/names.
+- **Build artifacts from `examples/`** inside the test (`docker build -t ...`).
+  Don't assume an image is already on the machine.
+
+When adding a new external integration (a new runner, a new provider),
+template a new integration test from the deploy one. Keep `requireDocker` /
+`requireTofu` helpers in a shared `internal/integrationtest/` package once
+you have more than one.
+
+## Anti-patterns to flag in review
+
+- `reflect.DeepEqual(...)` followed by `t.Errorf("got %+v want %+v", a, b)`
+  on anything bigger than a 2-field struct. Replace with `cmp.Diff`.
+- Substring assertions against generated text. Replace with a golden file.
+- Tests that read or write outside `t.TempDir()`.
+- Tests that depend on `examples/` paths via `findRepoRoot`-style walks
+  outside of the dedicated end-to-end integration test. Use
+  `internal/<pkg>/testdata/` instead.
+- `time.Sleep` for synchronization. Use channels, `context`, or polling with
+  a deadline.
+- Integration tests that `t.Skipf` unconditionally — they're dead code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,33 +1,63 @@
 # CLAUDE.md
 
-Mandatory practices for development and testing in this repo.
+Mandatory rules. Detailed how-tos and templates live in
+`.claude/skills/testing/SKILL.md` — invoke that skill when adding or
+substantially changing tests.
 
 ## Development
 
-- Target the Go toolchain in `go.mod` (currently `go 1.25`). Run `go build ./...` and `go vet ./...` before committing.
-- Format with `gofmt` (tabs, standard imports). No new external deps without a clear reason — the stdlib + the modules already in `go.mod` cover most needs.
-- Keep packages under `internal/` cohesive: one responsibility per package, exported surface minimal. Wire dependencies via small interfaces (see `runner.Runner`, `store.Store`) so they can be faked in tests.
-- Return errors with `fmt.Errorf("...: %w", err)`; never `panic` on user input or I/O.
+- Target the Go toolchain in `go.mod` (currently `go 1.25`). `go build ./...`,
+  `go vet ./...`, and `go vet -tags=integration ./...` must pass before
+  committing. The integration-tagged vet catches breakage in tests that the
+  default lane skips.
+- Format with `gofmt` (tabs, standard imports). Don't add external deps without
+  a clear reason — the stdlib + the modules already in `go.mod` cover most
+  needs. Allowed test-only additions: `github.com/google/go-cmp/cmp` for
+  diffs, `rsc.io/script/scripttest` for CLI tests.
+- Keep packages under `internal/` cohesive: one responsibility per package,
+  exported surface minimal. Wire dependencies via small interfaces (see
+  `runner.Runner`, `store.Store`) so they can be faked in tests.
+- Return errors with `fmt.Errorf("...: %w", err)`; never `panic` on user input
+  or I/O.
 
-## Unit tests (mandatory)
+## Testing — required outcomes
 
-- Every exported function or behavior in `internal/` and `api/` must have a unit test in the same package, file `<thing>_test.go`.
-- Use the standard library `testing` package only — **do not** add `testify`, `gomega`, or other assertion libs. Use `t.Fatalf` for setup/precondition failures and `t.Errorf` to keep going on independent assertions.
-- Prefer table-driven tests (`tests := []struct{...}{...}` + `t.Run(tc.name, ...)`) when covering more than two cases of the same shape.
-- Put filesystem state under `t.TempDir()`. Mark helpers with `t.Helper()`. Never read or write outside the temp dir or the repo's own `examples/`.
-- Tests must be hermetic and parallel-safe: no network, no `time.Sleep` for synchronization, no reliance on `$HOME`, ambient env, or current working directory. Set env via `t.Setenv`.
-- Default `go test ./...` must pass on a clean machine with only the Go toolchain installed.
+These are the properties every test must satisfy. The skill explains *how*.
 
-## Integration tests (mandatory rules)
+1. **Defaults stay green and fast.** `go test -race -count=1 ./...` on a clean
+   machine with only the Go toolchain must pass. No network, no ambient env,
+   no current-working-dir assumptions, no `time.Sleep` for synchronization,
+   no writes outside `t.TempDir()`. Set env via `t.Setenv`.
+2. **Parallel-safe by default.** Every test calls `t.Parallel()` unless there
+   is a documented reason not to (e.g. `t.Setenv` in a parent test).
+3. **Failures are actionable.** A failing assertion must show the agent what
+   changed, not just that something changed. Use `cmp.Diff` for non-trivial
+   structs; use golden files for generated text (HCL, JSON, CLI output) with
+   a `-update` flag to regenerate. Substring matches against generated output
+   are not acceptable for new code.
+4. **Every exported behavior in `internal/` and `api/` has a unit test** in
+   the same package, file `<thing>_test.go`. Prefer table-driven tests when
+   covering more than two cases of the same shape.
+5. **CLI behavior is tested at the CLI.** Changes to `cmd/openporch/` must be
+   covered by a testscript (`*.txtar`) case, not only by package-level tests.
+6. **Integration tests cover the contract with the outside world.** They live
+   next to the code under test and must:
+   - start with `//go:build integration` so default `go test ./...` skips them;
+   - probe their prereq (`docker`, `tofu`) and `t.Skipf` when missing locally,
+     but **fail** when `CI=true` and the prereq is missing — silent skips in CI
+     are a bug;
+   - exercise the package's public API as a black-box (`package <pkg>_test`);
+   - put all state under `t.TempDir()`, use non-default ports/names to avoid
+     collisions, and register teardown with `t.Cleanup` that runs even on
+     failure;
+   - wrap the operation in `context.WithTimeout` and finish within the suite's
+     `-timeout` ceiling;
+   - build any image/module they need from `examples/` inside the test rather
+     than depending on machine state.
+7. **Assertion libraries are limited.** Allowed: stdlib `testing`, `go-cmp`,
+   `scripttest`. Banned: `testify` (its `require` hides control flow) and any
+   library that swallows the `*testing.T` API.
 
-Integration tests cover real behavior against external systems we depend on: the OpenTofu CLI (`tofu`), Docker, and the on-disk state layout end-to-end. They live next to the code under test and follow these rules:
-
-1. **Build tag.** First line is `//go:build integration`. They never run under the default `go test ./...`. Run with `go test -tags=integration -timeout=5m ./...`.
-2. **Skip, don't fail, when prerequisites are missing.** Probe the dependency at the top of the test (e.g. `exec.Command("docker", "version").Run()`, `exec.LookPath("tofu")`) and call `t.Skipf` if absent. CI without Docker must still go green on `-tags=integration` for unrelated suites.
-3. **Black-box package.** Use `package <pkg>_test` and exercise the public API (`deploy.Run`, `store.FS`, `runner.LocalTofu`) — not internals. The integration test should resemble how `cmd/openporch` uses the package.
-4. **Isolated state.** Always use `t.TempDir()` as the state root. Never write to `.openporch/` in the repo. Pick non-default ports/names (see `host_port: 18080` in `internal/deploy/integration_test.go`) so the test doesn't collide with a developer's running stack.
-5. **Always tear down.** Register cleanup with `t.Cleanup` (or `defer`) that runs `destroy` even when the test fails partway. Leaking Docker containers or `tofu` state breaks the next run.
-6. **Bounded.** Wrap the operation in `context.WithTimeout`; the whole test must finish within `-timeout=5m`. Long-running suites get their own `_slow_test.go` behind an additional tag.
-7. **Real artifacts only.** If the test needs an image/module, build it from `examples/` inside the test — don't depend on something that "should already be on the machine".
-
-When adding a new external integration (a new runner, a new provider), add an integration test alongside the unit tests; the unit tests cover logic, the integration test covers the contract with the outside world.
+When adding a new external integration (a new runner, a new provider), add an
+integration test alongside the unit tests; the unit tests cover logic, the
+integration test covers the contract with the outside world.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# CLAUDE.md
+
+Mandatory practices for development and testing in this repo.
+
+## Development
+
+- Target the Go toolchain in `go.mod` (currently `go 1.25`). Run `go build ./...` and `go vet ./...` before committing.
+- Format with `gofmt` (tabs, standard imports). No new external deps without a clear reason — the stdlib + the modules already in `go.mod` cover most needs.
+- Keep packages under `internal/` cohesive: one responsibility per package, exported surface minimal. Wire dependencies via small interfaces (see `runner.Runner`, `store.Store`) so they can be faked in tests.
+- Return errors with `fmt.Errorf("...: %w", err)`; never `panic` on user input or I/O.
+
+## Unit tests (mandatory)
+
+- Every exported function or behavior in `internal/` and `api/` must have a unit test in the same package, file `<thing>_test.go`.
+- Use the standard library `testing` package only — **do not** add `testify`, `gomega`, or other assertion libs. Use `t.Fatalf` for setup/precondition failures and `t.Errorf` to keep going on independent assertions.
+- Prefer table-driven tests (`tests := []struct{...}{...}` + `t.Run(tc.name, ...)`) when covering more than two cases of the same shape.
+- Put filesystem state under `t.TempDir()`. Mark helpers with `t.Helper()`. Never read or write outside the temp dir or the repo's own `examples/`.
+- Tests must be hermetic and parallel-safe: no network, no `time.Sleep` for synchronization, no reliance on `$HOME`, ambient env, or current working directory. Set env via `t.Setenv`.
+- Default `go test ./...` must pass on a clean machine with only the Go toolchain installed.
+
+## Integration tests (mandatory rules)
+
+Integration tests cover real behavior against external systems we depend on: the OpenTofu CLI (`tofu`), Docker, and the on-disk state layout end-to-end. They live next to the code under test and follow these rules:
+
+1. **Build tag.** First line is `//go:build integration`. They never run under the default `go test ./...`. Run with `go test -tags=integration -timeout=5m ./...`.
+2. **Skip, don't fail, when prerequisites are missing.** Probe the dependency at the top of the test (e.g. `exec.Command("docker", "version").Run()`, `exec.LookPath("tofu")`) and call `t.Skipf` if absent. CI without Docker must still go green on `-tags=integration` for unrelated suites.
+3. **Black-box package.** Use `package <pkg>_test` and exercise the public API (`deploy.Run`, `store.FS`, `runner.LocalTofu`) — not internals. The integration test should resemble how `cmd/openporch` uses the package.
+4. **Isolated state.** Always use `t.TempDir()` as the state root. Never write to `.openporch/` in the repo. Pick non-default ports/names (see `host_port: 18080` in `internal/deploy/integration_test.go`) so the test doesn't collide with a developer's running stack.
+5. **Always tear down.** Register cleanup with `t.Cleanup` (or `defer`) that runs `destroy` even when the test fails partway. Leaking Docker containers or `tofu` state breaks the next run.
+6. **Bounded.** Wrap the operation in `context.WithTimeout`; the whole test must finish within `-timeout=5m`. Long-running suites get their own `_slow_test.go` behind an additional tag.
+7. **Real artifacts only.** If the test needs an image/module, build it from `examples/` inside the test — don't depend on something that "should already be on the machine".
+
+When adding a new external integration (a new runner, a new provider), add an integration test alongside the unit tests; the unit tests cover logic, the integration test covers the contract with the outside world.


### PR DESCRIPTION
This PR establishes mandatory development and testing standards for the openporch repository by introducing two new documentation files.

## Summary
Added comprehensive testing guidelines and development rules to ensure consistent, maintainable test coverage and code quality across the project.

## Changes

- **`.claude/skills/testing/SKILL.md`**: A detailed testing playbook covering:
  - How to choose the appropriate test layer (unit, CLI, integration) based on what's being changed
  - Unit test conventions (file naming, `t.Parallel()`, table-driven patterns, fakes vs real implementations)
  - CLI testing using testscript (`.txtar` files) for public command behavior
  - Golden file patterns for generated text (HCL, JSON, error messages)
  - Integration test structure with Docker/tofu prerequisites, teardown patterns, and CI-vs-local skip asymmetry
  - Anti-patterns to flag during code review

- **`CLAUDE.md`**: Mandatory rules covering:
  - Development standards (Go toolchain version, formatting, dependency constraints, error handling)
  - Seven required testing outcomes that all tests must satisfy:
    1. Fast, isolated tests with no external dependencies
    2. Parallel-safe by default
    3. Actionable failure messages using `cmp.Diff` and golden files
    4. Unit test coverage for all exported behavior
    5. CLI behavior tested at the CLI layer
    6. Integration tests with proper prereq handling and teardown
    7. Limited assertion libraries (stdlib, go-cmp, scripttest only)

## Implementation Details

The skill document provides templates and concrete examples for each test pattern, making it easy for contributors to follow best practices. The CLAUDE.md rules are intentionally prescriptive to maintain consistency and catch common pitfalls (e.g., substring assertions on generated output, tests that skip silently in CI, ambient environment dependencies).

The integration test guidance includes specific patterns like non-default ports (`18080`, `15433`) to avoid collisions and fresh-context teardown to ensure cleanup runs even on timeout.

https://claude.ai/code/session_019roFRUsTtSccvJvx6cRKUe