### PR TITLE
Add runner resolution logic based on platform config rules

### DIFF
--- a/cmd/openporch/cmd_deploy.go
+++ b/cmd/openporch/cmd_deploy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/krbrudeli/openporch/internal/config"
 	"github.com/krbrudeli/openporch/internal/deploy"
 	"github.com/krbrudeli/openporch/internal/manifest"
-	"github.com/krbrudeli/openporch/internal/runner"
 	"github.com/krbrudeli/openporch/internal/store"
 	"github.com/krbrudeli/openporch/internal/store/db"
 )
@@ -48,11 +47,11 @@ func newDeployCmd() *cobra.Command {
 				return fmt.Errorf("project not set: pass --project or set metadata.project")
 			}
 
-			s := &store.FS{Root: stateRoot}
-			r := &runner.LocalTofu{
-				BinaryPath:     tofuBinary,
-				PluginCacheDir: filepath.Join(stateRoot, "plugin-cache"),
+			runnerID, r, err := resolveRunner(cfg, project, env, envType, stateRoot, tofuBinary)
+			if err != nil {
+				return err
 			}
+			s := &store.FS{Root: stateRoot}
 			d, err := db.Open(stateRoot)
 			if err != nil {
 				return err
@@ -60,7 +59,7 @@ func newDeployCmd() *cobra.Command {
 			defer d.Close()
 
 			res, err := deploy.Run(ctx, deploy.Options{
-				Manifest: m, Platform: cfg, Store: s, Runner: r,
+				Manifest: m, Platform: cfg, Store: s, Runner: r, RunnerID: runnerID,
 				ProjectID: project, EnvID: env, EnvTypeID: envType,
 				Recorder: db.NewRecorder(d),
 			})

--- a/cmd/openporch/cmd_destroy.go
+++ b/cmd/openporch/cmd_destroy.go
@@ -11,7 +11,6 @@ import (
 	"github.com/krbrudeli/openporch/internal/config"
 	"github.com/krbrudeli/openporch/internal/deploy"
 	"github.com/krbrudeli/openporch/internal/manifest"
-	"github.com/krbrudeli/openporch/internal/runner"
 	"github.com/krbrudeli/openporch/internal/store"
 	"github.com/krbrudeli/openporch/internal/store/db"
 )
@@ -48,11 +47,11 @@ func newDestroyCmd() *cobra.Command {
 				return fmt.Errorf("project not set: pass --project or set metadata.project")
 			}
 
-			s := &store.FS{Root: stateRoot}
-			r := &runner.LocalTofu{
-				BinaryPath:     tofuBinary,
-				PluginCacheDir: filepath.Join(stateRoot, "plugin-cache"),
+			runnerID, r, err := resolveRunner(cfg, project, env, envType, stateRoot, tofuBinary)
+			if err != nil {
+				return err
 			}
+			s := &store.FS{Root: stateRoot}
 			d, err := db.Open(stateRoot)
 			if err != nil {
 				return err
@@ -61,7 +60,7 @@ func newDestroyCmd() *cobra.Command {
 
 			res, err := deploy.Destroy(ctx, deploy.DestroyOptions{
 				Options: deploy.Options{
-					Manifest: m, Platform: cfg, Store: s, Runner: r,
+					Manifest: m, Platform: cfg, Store: s, Runner: r, RunnerID: runnerID,
 					ProjectID: project, EnvID: env, EnvTypeID: envType,
 					Recorder: db.NewRecorder(d),
 				},

--- a/cmd/openporch/runner_resolve.go
+++ b/cmd/openporch/runner_resolve.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+	"github.com/krbrudeli/openporch/internal/match"
+	"github.com/krbrudeli/openporch/internal/runner"
+)
+
+// resolveRunner picks the right runner for the given (project, envType) pair
+// using runner rules from the platform config.
+func resolveRunner(
+	cfg *v1.PlatformConfig,
+	project, env, envType, stateRoot, binaryPath string,
+) (string, runner.Runner, error) {
+	ctx := match.Context{
+		ProjectID: project,
+		EnvID:     env,
+		EnvTypeID: envType,
+	}
+	runnerID, err := match.Runner(cfg.RunnerRules, ctx)
+	if err != nil {
+		return "", nil, fmt.Errorf("no runner matched (project=%s env=%s env_type=%s): %w",
+			project, env, envType, err)
+	}
+	runnerCfg, ok := cfg.Runners[runnerID]
+	if !ok {
+		return "", nil, fmt.Errorf("runner rule resolved runner_id=%q but no such runner is defined", runnerID)
+	}
+	r, err := runner.FromConfig(runnerCfg, binaryPath, filepath.Join(stateRoot, "plugin-cache"))
+	if err != nil {
+		return "", nil, err
+	}
+	return runnerID, r, nil
+}

--- a/cmd/openporch/runner_resolve_test.go
+++ b/cmd/openporch/runner_resolve_test.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+	"github.com/krbrudeli/openporch/internal/runner"
+)
+
+func cfg(runners map[string]v1.Runner, rules []v1.RunnerRule) *v1.PlatformConfig {
+	return &v1.PlatformConfig{Runners: runners, RunnerRules: rules}
+}
+
+func TestResolveRunner_catchAll(t *testing.T) {
+	c := cfg(
+		map[string]v1.Runner{"lt": {ID: "lt", Type: "local-tofu"}},
+		[]v1.RunnerRule{{ID: "catchall", RunnerID: "lt"}},
+	)
+	id, r, err := resolveRunner(c, "proj", "default", "local", t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "lt" {
+		t.Errorf("runner_id = %q, want lt", id)
+	}
+	if _, ok := r.(*runner.LocalTofu); !ok {
+		t.Errorf("expected *runner.LocalTofu, got %T", r)
+	}
+}
+
+func TestResolveRunner_specificRuleBeatsGeneric(t *testing.T) {
+	c := cfg(
+		map[string]v1.Runner{
+			"generic":  {ID: "generic", Type: "local-tofu"},
+			"specific": {ID: "specific", Type: "local-tofu"},
+		},
+		[]v1.RunnerRule{
+			{ID: "catchall", RunnerID: "generic"},
+			{ID: "prod", RunnerID: "specific", EnvTypeID: "production"},
+		},
+	)
+	id, _, err := resolveRunner(c, "proj", "default", "production", t.TempDir(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "specific" {
+		t.Errorf("runner_id = %q, want specific", id)
+	}
+}
+
+func TestResolveRunner_pluginCacheUnderStateRoot(t *testing.T) {
+	stateRoot := t.TempDir()
+	c := cfg(
+		map[string]v1.Runner{"lt": {ID: "lt", Type: "local-tofu"}},
+		[]v1.RunnerRule{{ID: "catchall", RunnerID: "lt"}},
+	)
+	_, r, err := resolveRunner(c, "proj", "default", "local", stateRoot, "")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	lt := r.(*runner.LocalTofu)
+	want := filepath.Join(stateRoot, "plugin-cache")
+	if lt.PluginCacheDir != want {
+		t.Errorf("PluginCacheDir = %q, want %q", lt.PluginCacheDir, want)
+	}
+}
+
+func TestResolveRunner_binaryPathForwarded(t *testing.T) {
+	c := cfg(
+		map[string]v1.Runner{"lt": {ID: "lt", Type: "local-tofu"}},
+		[]v1.RunnerRule{{ID: "catchall", RunnerID: "lt"}},
+	)
+	_, r, err := resolveRunner(c, "proj", "default", "local", t.TempDir(), "/custom/tofu")
+	if err != nil {
+		t.Fatalf("unexpected: %v", err)
+	}
+	lt := r.(*runner.LocalTofu)
+	if lt.BinaryPath != "/custom/tofu" {
+		t.Errorf("BinaryPath = %q, want /custom/tofu", lt.BinaryPath)
+	}
+}
+
+func TestResolveRunner_noMatchNamesContext(t *testing.T) {
+	c := cfg(
+		map[string]v1.Runner{"cloud": {ID: "cloud", Type: "local-tofu"}},
+		[]v1.RunnerRule{{ID: "prod-only", RunnerID: "cloud", EnvTypeID: "production"}},
+	)
+	_, _, err := resolveRunner(c, "myproj", "myenv", "local", t.TempDir(), "")
+	if err == nil {
+		t.Fatal("expected error when no rule matches, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"myproj", "myenv", "local"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q does not mention %q", msg, want)
+		}
+	}
+}
+
+func TestResolveRunner_unsupportedTypeReturnsError(t *testing.T) {
+	c := cfg(
+		map[string]v1.Runner{"cloud": {ID: "cloud", Type: "eks-fargate"}},
+		[]v1.RunnerRule{{ID: "catchall", RunnerID: "cloud"}},
+	)
+	_, _, err := resolveRunner(c, "proj", "default", "local", t.TempDir(), "")
+	if err == nil {
+		t.Fatal("expected error for unsupported type, got nil")
+	}
+	if !strings.Contains(err.Error(), "eks-fargate") {
+		t.Errorf("error %q should mention unsupported type", err.Error())
+	}
+}

--- a/examples/platform/runner-rules.yaml
+++ b/examples/platform/runner-rules.yaml
@@ -1,0 +1,4 @@
+apiVersion: openporch/v1alpha1
+kind: RunnerRule
+id: catchall
+runner_id: local-tofu

--- a/examples/platform/runners.yaml
+++ b/examples/platform/runners.yaml
@@ -3,8 +3,3 @@ kind: Runner
 id: local-tofu
 type: local-tofu
 description: Runs OpenTofu on the host.
----
-apiVersion: openporch/v1alpha1
-kind: RunnerRule
-id: catchall
-runner_id: local-tofu

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -34,6 +34,7 @@ type Options struct {
 	OrgID        string // optional, surfaced via ${context.org_id}
 	Store        *store.FS
 	Runner       runner.Runner
+	RunnerID     string // config-level runner ID for recording; overrides the type-derived fallback
 	DeploymentID string // identifier used for log paths; auto-set if empty
 
 	// Recorder optionally persists deployment history. When nil, the
@@ -165,7 +166,10 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 			ManifestYAML: string(manifestYAML), GraphJSON: graphJSON,
 		})
 	}
-	rid := runnerID(o.Runner)
+	rid := o.RunnerID
+	if rid == "" {
+		rid = runnerID(o.Runner)
+	}
 
 	// Apply each resource in order. v0 = sequential; concurrency-per-wave
 	// arrives in v0.5 once we have a second runner type to test against.

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -1,0 +1,129 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+	"github.com/krbrudeli/openporch/internal/runner"
+	"github.com/krbrudeli/openporch/internal/store"
+)
+
+// stubRunner satisfies runner.Runner without invoking tofu.
+type stubRunner struct {
+	outputs map[string]any
+}
+
+func (s *stubRunner) Apply(_ context.Context, _, _ string) (*runner.Result, error) {
+	return &runner.Result{Outputs: s.outputs}, nil
+}
+
+func (s *stubRunner) Destroy(_ context.Context, _, _ string) error {
+	return nil
+}
+
+// captureRecorder captures every ResourceRecord written by the pipeline.
+type captureRecorder struct {
+	resources []ResourceRecord
+}
+
+func (c *captureRecorder) StartDeployment(_ context.Context, _ DeploymentRecord) error { return nil }
+func (c *captureRecorder) RecordResource(_ context.Context, _ string, r ResourceRecord) error {
+	c.resources = append(c.resources, r)
+	return nil
+}
+func (c *captureRecorder) FinishDeployment(_ context.Context, _ string, _ string, _ time.Time) error {
+	return nil
+}
+
+// minimalPlatform returns a PlatformConfig with one resource type and one
+// inline module wired up by a catch-all rule. No providers are needed.
+func minimalPlatform(t *testing.T) *v1.PlatformConfig {
+	t.Helper()
+	rt := v1.ResourceType{ID: "workload"}
+	mod := v1.Module{
+		ID:               "workload-stub",
+		ResourceType:     "workload",
+		ModuleSource:     "inline",
+		ModuleSourceCode: ``,
+	}
+	rule := v1.ModuleRule{
+		ID: "catchall", ResourceType: "workload", ModuleID: "workload-stub",
+	}
+	return &v1.PlatformConfig{
+		RootDir:       t.TempDir(),
+		ResourceTypes: map[string]v1.ResourceType{"workload": rt},
+		Modules:       map[string]v1.Module{"workload-stub": mod},
+		ModuleRules:   []v1.ModuleRule{rule},
+		Providers:     map[string]v1.Provider{},
+		Runners:       map[string]v1.Runner{},
+	}
+}
+
+// minimalManifest returns a one-workload manifest that exercises the pipeline.
+func minimalManifest() *v1.Manifest {
+	return &v1.Manifest{
+		APIVersion: v1.APIVersion,
+		Kind:       v1.KindApplication,
+		Metadata:   v1.ManifestMetadata{Name: "test-app"},
+		Workloads: map[string]v1.Workload{
+			"api": {Type: "workload"},
+		},
+	}
+}
+
+func TestRun_runnerIDPropagatedToRecorder(t *testing.T) {
+	rec := &captureRecorder{}
+	_, err := Run(context.Background(), Options{
+		Manifest:  minimalManifest(),
+		Platform:  minimalPlatform(t),
+		Store:     &store.FS{Root: t.TempDir()},
+		Runner:    &stubRunner{},
+		RunnerID:  "my-configured-runner",
+		ProjectID: "proj",
+		EnvID:     "test",
+		EnvTypeID: "local",
+		Recorder:  rec,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rec.resources) == 0 {
+		t.Fatal("no resources were recorded")
+	}
+	for _, r := range rec.resources {
+		if r.RunnerID != "my-configured-runner" {
+			t.Errorf("resource %q: RunnerID = %q, want my-configured-runner", r.ResourceKey, r.RunnerID)
+		}
+	}
+}
+
+func TestRun_runnerIDFallsBackToTypeDerivedStringWhenUnset(t *testing.T) {
+	stub := &stubRunner{}
+	rec := &captureRecorder{}
+	_, err := Run(context.Background(), Options{
+		Manifest:  minimalManifest(),
+		Platform:  minimalPlatform(t),
+		Store:     &store.FS{Root: t.TempDir()},
+		Runner:    stub,
+		// RunnerID intentionally not set; pipeline falls back to runnerID(o.Runner).
+		ProjectID: "proj",
+		EnvID:     "test",
+		EnvTypeID: "local",
+		Recorder:  rec,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(rec.resources) == 0 {
+		t.Fatal("no resources were recorded")
+	}
+	wantID := fmt.Sprintf("%T", stub)
+	for _, r := range rec.resources {
+		if r.RunnerID != wantID {
+			t.Errorf("resource %q: RunnerID = %q, want %q (type-derived fallback)", r.ResourceKey, r.RunnerID, wantID)
+		}
+	}
+}

--- a/internal/runner/from_config.go
+++ b/internal/runner/from_config.go
@@ -1,0 +1,21 @@
+package runner
+
+import (
+	"fmt"
+
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+)
+
+// FromConfig constructs a Runner from a platform Runner definition.
+// binaryPath and pluginCacheDir are forwarded to LocalTofu for type "local-tofu".
+func FromConfig(r v1.Runner, binaryPath, pluginCacheDir string) (Runner, error) {
+	switch r.Type {
+	case v1.RunnerLocalTofu:
+		return &LocalTofu{
+			BinaryPath:     binaryPath,
+			PluginCacheDir: pluginCacheDir,
+		}, nil
+	default:
+		return nil, fmt.Errorf("runner: unsupported type %q for runner %q", r.Type, r.ID)
+	}
+}

--- a/internal/runner/from_config_test.go
+++ b/internal/runner/from_config_test.go
@@ -1,0 +1,50 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+)
+
+func TestFromConfig_localTofu(t *testing.T) {
+	r, err := FromConfig(v1.Runner{ID: "lt", Type: v1.RunnerLocalTofu}, "/usr/bin/tofu", "/tmp/cache")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lt, ok := r.(*LocalTofu)
+	if !ok {
+		t.Fatalf("expected *LocalTofu, got %T", r)
+	}
+	if lt.BinaryPath != "/usr/bin/tofu" {
+		t.Errorf("BinaryPath = %q, want /usr/bin/tofu", lt.BinaryPath)
+	}
+	if lt.PluginCacheDir != "/tmp/cache" {
+		t.Errorf("PluginCacheDir = %q, want /tmp/cache", lt.PluginCacheDir)
+	}
+}
+
+func TestFromConfig_emptyBinaryPath(t *testing.T) {
+	r, err := FromConfig(v1.Runner{ID: "lt", Type: v1.RunnerLocalTofu}, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lt := r.(*LocalTofu)
+	if lt.BinaryPath != "" {
+		t.Errorf("BinaryPath = %q, want empty (PATH lookup)", lt.BinaryPath)
+	}
+}
+
+func TestFromConfig_unsupportedType(t *testing.T) {
+	_, err := FromConfig(v1.Runner{ID: "cloud-runner", Type: "eks-fargate"}, "", "")
+	if err == nil {
+		t.Fatal("expected error for unsupported type, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "eks-fargate") {
+		t.Errorf("error %q does not mention type", msg)
+	}
+	if !strings.Contains(msg, "cloud-runner") {
+		t.Errorf("error %q does not mention runner ID", msg)
+	}
+}


### PR DESCRIPTION
## Summary
This PR introduces a runner resolution system that dynamically selects the appropriate runner based on platform configuration rules, rather than hardcoding the LocalTofu runner. It extracts runner instantiation logic into reusable functions and updates the deploy and destroy commands to use the new resolution mechanism.

## Key Changes
- **New `resolveRunner()` function** (`cmd/openporch/runner_resolve.go`): Implements runner selection logic by matching project/environment/environment-type against configured runner rules, then instantiating the matched runner from its configuration
- **New `runner.FromConfig()` function** (`internal/runner/from_config.go`): Factory function that constructs a Runner instance from a platform Runner definition, currently supporting the `local-tofu` runner type
- **Updated deploy and destroy commands**: Replaced hardcoded LocalTofu instantiation with calls to `resolveRunner()`, removing direct runner package imports
- **Enhanced `deploy.Options`**: Added `RunnerID` field to record the config-level runner ID used for a deployment, with fallback to type-derived ID if not explicitly set
- **Reorganized example configuration**: Moved RunnerRule definitions from `runners.yaml` to a dedicated `runner-rules.yaml` file for better separation of concerns

## Implementation Details
- Runner resolution uses the existing `match.Runner()` function to evaluate rules against a context containing project ID, environment ID, and environment type
- The resolver validates that matched runner IDs are actually defined in the platform config before instantiation
- Plugin cache directory is automatically derived as `{stateRoot}/plugin-cache` during runner instantiation
- The RunnerID is now explicitly tracked through the deployment pipeline for better auditability and future extensibility

https://claude.ai/code/session_01FNTBb9PVZywQvAkhyhjrdk