### PR TITLE
Add dry-run mode to deployment pipeline

### DIFF
--- a/cmd/openporch/cmd_deploy.go
+++ b/cmd/openporch/cmd_deploy.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -24,6 +25,8 @@ func newDeployCmd() *cobra.Command {
 		envType     string
 		stateRoot   string
 		tofuBinary  string
+		dryRun      bool
+		renderDir   string
 	)
 	cmd := &cobra.Command{
 		Use:   "deploy <manifest.yaml>",
@@ -51,20 +54,43 @@ func newDeployCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			s := &store.FS{Root: stateRoot}
-			d, err := db.Open(stateRoot)
+
+			opts := deploy.Options{
+				Manifest: m, Platform: cfg, Store: &store.FS{Root: stateRoot},
+				Runner: r, RunnerID: runnerID,
+				ProjectID: project, EnvID: env, EnvTypeID: envType,
+				DryRun: dryRun, RenderDir: renderDir,
+			}
+			if !dryRun {
+				d, err := db.Open(stateRoot)
+				if err != nil {
+					return err
+				}
+				defer d.Close()
+				opts.Recorder = db.NewRecorder(d)
+			}
+
+			res, err := deploy.Run(ctx, opts)
 			if err != nil {
 				return err
 			}
-			defer d.Close()
 
-			res, err := deploy.Run(ctx, deploy.Options{
-				Manifest: m, Platform: cfg, Store: s, Runner: r, RunnerID: runnerID,
-				ProjectID: project, EnvID: env, EnvTypeID: envType,
-				Recorder: db.NewRecorder(d),
-			})
-			if err != nil {
-				return err
+			if dryRun {
+				fmt.Printf("Dry-run complete. %d resource(s) would be deployed:\n\n", len(res.DryRunResources))
+				for _, r := range res.DryRunResources {
+					fmt.Printf("  %-40s  module=%-30s  type=%s", r.Key, r.ModuleID, r.Type)
+					if r.Class != "" {
+						fmt.Printf("  class=%s", r.Class)
+					}
+					if len(r.Providers) > 0 {
+						fmt.Printf("  providers=%s", strings.Join(r.Providers, ","))
+					}
+					fmt.Println()
+				}
+				if renderDir != "" {
+					fmt.Printf("\nRendered HCL written to: %s\n", renderDir)
+				}
+				return nil
 			}
 
 			fmt.Printf("\nDeployment %s succeeded.\n\n", res.DeploymentID)
@@ -111,5 +137,9 @@ func newDeployCmd() *cobra.Command {
 	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
 		"directory under which TF state and openporch metadata live")
 	cmd.Flags().StringVar(&tofuBinary, "tofu", "", "path to tofu binary (default: $PATH lookup)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"validate and render HCL without invoking tofu; prints a per-resource summary")
+	cmd.Flags().StringVar(&renderDir, "render-dir", "",
+		"with --dry-run: write rendered main.tf files here so you can run `tofu plan` manually")
 	return cmd
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -40,6 +41,15 @@ type Options struct {
 	// Recorder optionally persists deployment history. When nil, the
 	// pipeline runs without writing to any history store.
 	Recorder Recorder
+
+	// DryRun stops the pipeline after HCL render. No tofu init/apply is
+	// invoked, no state files are written, and no deployment row is recorded.
+	DryRun bool
+
+	// RenderDir, when non-empty and DryRun is true, receives the rendered
+	// main.tf files so the caller can run `tofu plan` manually.
+	// Layout: <RenderDir>/<safe-resource-key>/main.tf
+	RenderDir string
 }
 
 // runnerID returns a stable identifier for the runner type so it can be
@@ -57,11 +67,22 @@ func runnerID(r runner.Runner) string {
 	}
 }
 
+// DryRunResource summarises one resource in a dry-run pass.
+type DryRunResource struct {
+	Key       string
+	Type      string
+	Class     string
+	ID        string
+	ModuleID  string
+	Providers []string // provider types required (e.g. "docker", "random")
+}
+
 // Result summarises a deploy.
 type Result struct {
-	DeploymentID string
-	Resolved     map[string]map[string]any // graph-key -> outputs
-	Outputs      map[string]string         // manifest outputs
+	DeploymentID    string
+	Resolved        map[string]map[string]any // graph-key -> outputs
+	Outputs         map[string]string         // manifest outputs
+	DryRunResources []DryRunResource          // populated when Options.DryRun is true
 }
 
 // envVars implements expr.Vars over os.Getenv with TF_VAR_ prefix. This is
@@ -157,7 +178,7 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 	}
 
 	startedAt := time.Now().UTC()
-	if o.Recorder != nil {
+	if o.Recorder != nil && !o.DryRun {
 		manifestYAML, _ := yaml.Marshal(o.Manifest)
 		graphJSON, _ := serializeGraph(g)
 		_ = o.Recorder.StartDeployment(ctx, DeploymentRecord{
@@ -174,6 +195,7 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 	// Apply each resource in order. v0 = sequential; concurrency-per-wave
 	// arrives in v0.5 once we have a second runner type to test against.
 	resolved := map[string]map[string]any{}
+	var dryRunResources []DryRunResource
 	for _, n := range ordered {
 		mod := o.Platform.Modules[n.ModuleID]
 		ectx := expr.Context{
@@ -197,7 +219,7 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		if rerr != nil && !errors.Is(rerr, expr.ErrUnresolved) {
 			return nil, fmt.Errorf("deploy: resolve inputs for %s: %w", n.Key, rerr)
 		}
-		if errors.Is(rerr, expr.ErrUnresolved) {
+		if !o.DryRun && errors.Is(rerr, expr.ErrUnresolved) {
 			return nil, fmt.Errorf("deploy: unresolved placeholder in inputs of %s (likely a missing dependency edge): %w",
 				n.Key, rerr)
 		}
@@ -210,9 +232,13 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		outNames := outputNamesForType(o.Platform.ResourceTypes[n.Type])
 
 		moduleSource := mod.ModuleSource
+		var inlineModuleSrc string
 		if mod.ModuleSource == "inline" || mod.ModuleSourceCode != "" {
-			if err := o.Store.WriteInlineModule(o.ProjectID, o.EnvID, n.Key, mod.ModuleSourceCode); err != nil {
-				return nil, err
+			inlineModuleSrc = mod.ModuleSourceCode
+			if !o.DryRun {
+				if err := o.Store.WriteInlineModule(o.ProjectID, o.EnvID, n.Key, mod.ModuleSourceCode); err != nil {
+					return nil, err
+				}
 			}
 			moduleSource = "./module"
 		} else {
@@ -232,6 +258,24 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		if err != nil {
 			return nil, fmt.Errorf("deploy: render %s: %w", n.Key, err)
 		}
+		if o.DryRun {
+			providerTypes := make([]string, 0, len(providers))
+			for _, p := range providers {
+				providerTypes = append(providerTypes, p.Type)
+			}
+			sort.Strings(providerTypes)
+			dryRunResources = append(dryRunResources, DryRunResource{
+				Key: n.Key, Type: n.Type, Class: n.Class, ID: n.ID,
+				ModuleID: n.ModuleID, Providers: providerTypes,
+			})
+			if o.RenderDir != "" {
+				if err := writeDryRunHCL(o.RenderDir, n.Key, hcl, inlineModuleSrc); err != nil {
+					return nil, err
+				}
+			}
+			continue
+		}
+
 		workdir, err := o.Store.WriteRootTF(o.ProjectID, o.EnvID, n.Key, hcl)
 		if err != nil {
 			return nil, err
@@ -276,26 +320,28 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		}
 	}
 
-	// Resolve manifest-level outputs.
+	// Resolve manifest-level outputs. In dry-run, cross-resource placeholders
+	// can't be resolved (no outputs available), so ErrUnresolved is tolerated.
 	manifestOutputs := map[string]string{}
 	for k, v := range o.Manifest.Outputs {
 		ectx := expr.Context{
 			OrgID: o.OrgID, ProjectID: o.ProjectID, EnvID: o.EnvID, EnvTypeID: o.EnvTypeID,
 		}
 		s, err := expr.Resolve(v, ectx, stateView{g: g}, envVars{})
-		if err != nil {
+		if err != nil && (!o.DryRun || !errors.Is(err, expr.ErrUnresolved)) {
 			return nil, fmt.Errorf("deploy: resolve manifest output %q: %w", k, err)
 		}
 		manifestOutputs[k] = s
 	}
 
-	if o.Recorder != nil {
+	if o.Recorder != nil && !o.DryRun {
 		_ = o.Recorder.FinishDeployment(ctx, o.DeploymentID, "succeeded", time.Now().UTC())
 	}
 	return &Result{
-		DeploymentID: o.DeploymentID,
-		Resolved:     resolved,
-		Outputs:      manifestOutputs,
+		DeploymentID:    o.DeploymentID,
+		Resolved:        resolved,
+		Outputs:         manifestOutputs,
+		DryRunResources: dryRunResources,
 	}, nil
 }
 
@@ -392,6 +438,35 @@ func assembleProviders(
 func toJSON(v any) string {
 	b, _ := json.Marshal(v)
 	return string(b)
+}
+
+// writeDryRunHCL writes the rendered main.tf (and optional inline module
+// source) under renderDir/<safe-key>/ so the user can run `tofu plan`.
+func writeDryRunHCL(renderDir, key, hcl, inlineModuleSrc string) error {
+	safe := strings.Map(func(r rune) rune {
+		switch r {
+		case '|', '/', ' ':
+			return '_'
+		}
+		return r
+	}, key)
+	dir := filepath.Join(renderDir, safe)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("deploy: dry-run mkdir %s: %w", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(hcl), 0o644); err != nil {
+		return fmt.Errorf("deploy: dry-run write HCL for %s: %w", key, err)
+	}
+	if inlineModuleSrc != "" {
+		modDir := filepath.Join(dir, "module")
+		if err := os.MkdirAll(modDir, 0o755); err != nil {
+			return fmt.Errorf("deploy: dry-run mkdir module for %s: %w", key, err)
+		}
+		if err := os.WriteFile(filepath.Join(modDir, "main.tf"), []byte(inlineModuleSrc), 0o644); err != nil {
+			return fmt.Errorf("deploy: dry-run write inline module for %s: %w", key, err)
+		}
+	}
+	return nil
 }
 
 func safeAlias(id string) string {

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -3,6 +3,8 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,10 +15,12 @@ import (
 
 // stubRunner satisfies runner.Runner without invoking tofu.
 type stubRunner struct {
-	outputs map[string]any
+	outputs  map[string]any
+	applyCnt int
 }
 
 func (s *stubRunner) Apply(_ context.Context, _, _ string) (*runner.Result, error) {
+	s.applyCnt++
 	return &runner.Result{Outputs: s.outputs}, nil
 }
 
@@ -125,5 +129,95 @@ func TestRun_runnerIDFallsBackToTypeDerivedStringWhenUnset(t *testing.T) {
 		if r.RunnerID != wantID {
 			t.Errorf("resource %q: RunnerID = %q, want %q (type-derived fallback)", r.ResourceKey, r.RunnerID, wantID)
 		}
+	}
+}
+
+func TestRun_DryRunSkipsRunner(t *testing.T) {
+	t.Parallel()
+	stub := &stubRunner{}
+	rec := &captureRecorder{}
+	stateRoot := t.TempDir()
+
+	res, err := Run(context.Background(), Options{
+		Manifest:  minimalManifest(),
+		Platform:  minimalPlatform(t),
+		Store:     &store.FS{Root: stateRoot},
+		Runner:    stub,
+		RunnerID:  "local-tofu",
+		ProjectID: "proj",
+		EnvID:     "test",
+		EnvTypeID: "local",
+		Recorder:  rec,
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if stub.applyCnt != 0 {
+		t.Errorf("Runner.Apply called %d time(s); want 0 in dry-run", stub.applyCnt)
+	}
+	if len(rec.resources) != 0 {
+		t.Errorf("recorder captured %d resource(s); want 0 in dry-run", len(rec.resources))
+	}
+	if len(res.DryRunResources) != 1 {
+		t.Fatalf("DryRunResources len = %d, want 1", len(res.DryRunResources))
+	}
+	got := res.DryRunResources[0]
+	if got.ModuleID != "workload-stub" {
+		t.Errorf("DryRunResources[0].ModuleID = %q, want workload-stub", got.ModuleID)
+	}
+}
+
+func TestRun_DryRunNoStateFiles(t *testing.T) {
+	t.Parallel()
+	stateRoot := t.TempDir()
+
+	_, err := Run(context.Background(), Options{
+		Manifest:  minimalManifest(),
+		Platform:  minimalPlatform(t),
+		Store:     &store.FS{Root: stateRoot},
+		Runner:    &stubRunner{},
+		ProjectID: "proj",
+		EnvID:     "test",
+		EnvTypeID: "local",
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	stateDir := filepath.Join(stateRoot, "state")
+	if _, err := os.Stat(stateDir); err == nil {
+		t.Errorf("dry-run created state directory %s; want none", stateDir)
+	}
+}
+
+func TestRun_DryRunWritesRenderDir(t *testing.T) {
+	t.Parallel()
+	renderDir := t.TempDir()
+
+	_, err := Run(context.Background(), Options{
+		Manifest:  minimalManifest(),
+		Platform:  minimalPlatform(t),
+		Store:     &store.FS{Root: t.TempDir()},
+		Runner:    &stubRunner{},
+		ProjectID: "proj",
+		EnvID:     "test",
+		EnvTypeID: "local",
+		DryRun:    true,
+		RenderDir: renderDir,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// At least one main.tf should have been written under renderDir.
+	var found bool
+	_ = filepath.WalkDir(renderDir, func(path string, d os.DirEntry, err error) error {
+		if err == nil && !d.IsDir() && d.Name() == "main.tf" {
+			found = true
+		}
+		return nil
+	})
+	if !found {
+		t.Errorf("no main.tf found under render-dir %s", renderDir)
 	}
 }


### PR DESCRIPTION
## Summary
This PR adds a dry-run mode to the deployment pipeline that allows users to validate and render Terraform/OpenTofu HCL without actually executing infrastructure changes. This enables safer preview of deployments and manual `tofu plan` execution.

## Key Changes

- **New `Options` fields**: Added `DryRun` bool and `RenderDir` string to control dry-run behavior and output location
- **New `DryRunResource` type**: Captures resource metadata (key, type, class, ID, module, providers) for dry-run results
- **Updated `Result` type**: Added `DryRunResources` field to return summary of resources that would be deployed
- **Pipeline modifications**:
  - Skip recorder operations (StartDeployment/FinishDeployment) when in dry-run mode
  - Skip runner.Apply() invocations and state file writes when in dry-run mode
  - Skip inline module writes to store when in dry-run mode
  - Tolerate unresolved placeholders in inputs and manifest outputs during dry-run (since cross-resource outputs aren't available)
  - Collect provider types and resource metadata for each resource processed
- **HCL rendering**: Added `writeDryRunHCL()` function to write rendered main.tf files to `RenderDir/<safe-key>/` structure, including inline module sources when applicable
- **CLI integration**: Updated `cmd_deploy.go` to:
  - Add `--dry-run` and `--render-dir` flags
  - Skip database initialization in dry-run mode
  - Print formatted summary of resources that would be deployed
  - Display render directory location when provided
- **Tests**: Added three new test cases covering dry-run behavior:
  - Verification that runner.Apply() is not called
  - Verification that no state files are created
  - Verification that RenderDir receives rendered HCL files

## Implementation Details

- Resource keys are sanitized for filesystem safety by replacing `|`, `/`, and space characters with underscores
- Provider types are sorted alphabetically in the dry-run output for consistency
- Inline module source code is preserved in memory during dry-run and written to `<RenderDir>/<safe-key>/module/main.tf` if present
- Unresolved placeholder errors are only tolerated in dry-run mode; normal deployments still fail on unresolved dependencies

https://claude.ai/code/session_01RRXdkC8XBC1o2fmopUZhcQ