### PR TITLE
Fail integration tests when prerequisites are missing

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -199,24 +199,15 @@ package deploy_test
 
 import (
     "context"
-    "os"
-    "os/exec"
     "testing"
     "time"
+
+    "github.com/krbrudeli/openporch/internal/integrationtest"
 )
 
-func requireDocker(t *testing.T) {
-    t.Helper()
-    if err := exec.Command("docker", "version").Run(); err != nil {
-        if os.Getenv("CI") == "true" {
-            t.Fatalf("docker required in CI: %v", err)
-        }
-        t.Skipf("docker not available locally: %v", err)
-    }
-}
-
 func TestDeploy_endToEnd(t *testing.T) {
-    requireDocker(t)
+    integrationtest.RequireDocker(t)
+    integrationtest.RequireTofu(t)
     // Do NOT t.Parallel() integration tests that bind host resources.
 
     ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
@@ -243,10 +234,12 @@ func TestDeploy_endToEnd(t *testing.T) {
 
 Critical points:
 
-- **CI-vs-local skip asymmetry.** `t.Skipf` is fine on a developer's laptop
-  without Docker. In CI it must `t.Fatalf` — silent skips are how broken
-  integration tests stay green for weeks. The `requireDocker` helper above
-  encodes this; copy it for `tofu` and any future prereq.
+- **Prerequisites fail, never skip.** Integration tests are already guarded
+  behind `-tags=integration`, so missing Docker/OpenTofu means the opted-in
+  test environment is broken. Use
+  `internal/integrationtest.RequireDocker` and
+  `internal/integrationtest.RequireTofu` rather than inlining prerequisite
+  checks or calling `t.Skipf`.
 - **Non-default ports/names.** Pick something unlikely to collide with a
   developer's running stack. `host_port: 18080` and `host_port: 15433` in
   `internal/deploy/integration_test.go` are the existing convention.
@@ -259,9 +252,8 @@ Critical points:
   Don't assume an image is already on the machine.
 
 When adding a new external integration (a new runner, a new provider),
-template a new integration test from the deploy one. Keep `requireDocker` /
-`requireTofu` helpers in a shared `internal/integrationtest/` package once
-you have more than one.
+template a new integration test from the deploy one and keep any new
+CI-sensitive prerequisite checks in `internal/integrationtest/`.
 
 ## Anti-patterns to flag in review
 
@@ -274,4 +266,5 @@ you have more than one.
   `internal/<pkg>/testdata/` instead.
 - `time.Sleep` for synchronization. Use channels, `context`, or polling with
   a deadline.
-- Integration tests that `t.Skipf` unconditionally — they're dead code.
+- Integration tests that `t.Skipf` for missing prerequisites — the build tag is
+  the opt-in guard, so missing prerequisites should fail.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
         with:
           tofu_wrapper: false
 
+      - name: Verify Docker daemon
+        run: |
+          docker version
+          docker info
+
       - name: Integration tests
         id: integration
         run: go test -tags=integration -timeout=10m -v ./...

--- a/internal/deploy/integration_test.go
+++ b/internal/deploy/integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/krbrudeli/openporch/internal/config"
 	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/integrationtest"
 	"github.com/krbrudeli/openporch/internal/manifest"
 	"github.com/krbrudeli/openporch/internal/runner"
 	"github.com/krbrudeli/openporch/internal/store"
@@ -28,9 +29,8 @@ import (
 //
 // Run with: go test -tags=integration -timeout=5m ./internal/deploy/...
 func TestDeployFastAPIToLocalDocker(t *testing.T) {
-	if err := exec.Command("docker", "version").Run(); err != nil {
-		t.Skipf("docker daemon not reachable: %v", err)
-	}
+	integrationtest.RequireDocker(t)
+	integrationtest.RequireTofu(t)
 
 	repoRoot := findRepoRoot(t)
 	platformDir := filepath.Join(repoRoot, "examples", "platform")
@@ -130,12 +130,8 @@ func TestDeployFastAPIToLocalDocker(t *testing.T) {
 //
 // Run with: go test -tags=integration -timeout=10m ./internal/deploy/...
 func TestPlanOnlyFastAPIDemo(t *testing.T) {
-	if err := exec.Command("tofu", "version").Run(); err != nil {
-		t.Skipf("tofu binary not available: %v", err)
-	}
-	if err := exec.Command("docker", "version").Run(); err != nil {
-		t.Skipf("docker daemon not reachable: %v", err)
-	}
+	integrationtest.RequireTofu(t)
+	integrationtest.RequireDocker(t)
 
 	repoRoot := findRepoRoot(t)
 	platformDir := filepath.Join(repoRoot, "examples", "platform")

--- a/internal/integrationtest/require.go
+++ b/internal/integrationtest/require.go
@@ -1,0 +1,34 @@
+// Package integrationtest contains helpers for tests that exercise real
+// external tools rather than in-memory fakes.
+package integrationtest
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// RequireDocker fails when Docker is unavailable. Integration tests are already
+// guarded behind the integration build tag, so opting in means prerequisites
+// must be present.
+func RequireDocker(t *testing.T) {
+	t.Helper()
+
+	out, err := exec.Command("docker", "version").CombinedOutput()
+	if err == nil {
+		return
+	}
+	t.Fatalf("docker required for integration tests: %v\n%s", err, out)
+}
+
+// RequireTofu fails when OpenTofu is unavailable. Integration tests are already
+// guarded behind the integration build tag, so opting in means prerequisites
+// must be present.
+func RequireTofu(t *testing.T) {
+	t.Helper()
+
+	_, err := exec.LookPath("tofu")
+	if err == nil {
+		return
+	}
+	t.Fatalf("tofu required for integration tests: %v", err)
+}


### PR DESCRIPTION
## Summary
- add shared integrationtest prerequisite helpers for Docker and OpenTofu
- fail integration tests on missing prerequisites instead of skipping, since -tags=integration is the opt-in guard
- verify Docker daemon access explicitly before CI integration tests
- update testing guidance to use the shared helpers

Fixes #22

## Tests
- go test ./...
- go test -tags=integration -timeout=10m ./...