### PR TITLE
Add go vet check for integration build tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Vet (integration tag)
+        run: go vet -tags=integration ./...
+
       - name: Unit tests
         run: go test -race ./...
 


### PR DESCRIPTION
## Summary
Added a dedicated `go vet` check in the CI pipeline to validate code when built with the `integration` build tag.

## Key Changes
- Added a new CI step that runs `go vet -tags=integration ./...` to catch any vet issues specific to the integration build configuration
- This complements the existing `go vet` check which runs without build tags

## Details
The integration build tag may enable additional code paths or dependencies that should also pass Go's vet analysis. This ensures code quality is maintained across all build configurations used in the project.

https://claude.ai/code/session_01TkviDU5K8zhQ6dWnufXo6T