### PR TITLE
Adopt go-cmp for test diffs

### DIFF
--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -87,9 +87,16 @@ A fake should:
 
 ### Diffs over equality
 
-Use `github.com/google/go-cmp/cmp` for any struct or slice comparison larger
-than two fields. Write the diff message as `"X mismatch (-want +got):\n%s"`
-so the agent reading the failure can immediately see which field changed.
+Use `github.com/google/go-cmp/cmp` for non-trivial equality, and require it
+for any struct or slice comparison larger than two fields. Write the diff
+message as `"X mismatch (-want +got):\n%s"` so the agent reading the failure
+can immediately see which field changed.
+
+```go
+if diff := cmp.Diff(want, got); diff != "" {
+    t.Errorf("Load() mismatch (-want +got):\n%s", diff)
+}
+```
 
 For unexported fields, use `cmp.AllowUnexported(MyType{})` rather than
 exporting fields just for tests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,10 @@ These are the properties every test must satisfy. The skill explains *how*.
    is a documented reason not to (e.g. `t.Setenv` in a parent test).
 3. **Failures are actionable.** A failing assertion must show the agent what
    changed, not just that something changed. Use `cmp.Diff` for non-trivial
-   structs; use golden files for generated text (HCL, JSON, CLI output) with
-   a `-update` flag to regenerate. Substring matches against generated output
-   are not acceptable for new code.
+   equality, and require it for any struct or slice comparison larger than
+   two fields; use golden files for generated text (HCL, JSON, CLI output)
+   with a `-update` flag to regenerate. Substring matches against generated
+   output are not acceptable for new code.
 4. **Every exported behavior in `internal/` and `api/` has a unit test** in
    the same package, file `<thing>_test.go`. Prefer table-driven tests when
    covering more than two cases of the same shape.

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/krbrudeli/openporch
 go 1.25.0
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/hashicorp/terraform-exec v0.25.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -77,6 +77,7 @@ func (g *Graph) AddOrMerge(n *Node) error {
 			if !contains(existing.Aliases, a) {
 				existing.Aliases = append(existing.Aliases, a)
 			}
+			g.AliasIndex[a] = existing.Key
 		}
 		// Merge edges (deduped).
 		for _, e := range n.Edges {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
 )
 
@@ -43,14 +45,42 @@ func TestBuild_workloadAndSharedNodesCreated(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := g.AliasIndex["workloads.api"]; !ok {
-		t.Errorf("missing workload alias")
+	want := &Graph{
+		Nodes: map[string]*Node{
+			NodeKey("workload", v1.DefaultClass, "api"): {
+				Key:     NodeKey("workload", v1.DefaultClass, "api"),
+				Type:    "workload",
+				Class:   v1.DefaultClass,
+				ID:      "api",
+				Aliases: []string{"workloads.api"},
+				Edges:   []string{NodeKey("postgres", v1.DefaultClass, "workloads.api.db")},
+				Status:  "pending",
+			},
+			NodeKey("postgres", v1.DefaultClass, "workloads.api.db"): {
+				Key:     NodeKey("postgres", v1.DefaultClass, "workloads.api.db"),
+				Type:    "postgres",
+				Class:   v1.DefaultClass,
+				ID:      "workloads.api.db",
+				Aliases: []string{"workloads.api.db"},
+				Status:  "pending",
+			},
+			NodeKey("s3", v1.DefaultClass, "shared.bucket"): {
+				Key:     NodeKey("s3", v1.DefaultClass, "shared.bucket"),
+				Type:    "s3",
+				Class:   v1.DefaultClass,
+				ID:      "shared.bucket",
+				Aliases: []string{"shared.bucket"},
+				Status:  "pending",
+			},
+		},
+		AliasIndex: map[string]string{
+			"workloads.api":    NodeKey("workload", v1.DefaultClass, "api"),
+			"workloads.api.db": NodeKey("postgres", v1.DefaultClass, "workloads.api.db"),
+			"shared.bucket":    NodeKey("s3", v1.DefaultClass, "shared.bucket"),
+		},
 	}
-	if _, ok := g.AliasIndex["workloads.api.db"]; !ok {
-		t.Errorf("missing workload-scoped resource alias")
-	}
-	if _, ok := g.AliasIndex["shared.bucket"]; !ok {
-		t.Errorf("missing shared alias")
+	if diff := graphDiff(want, g); diff != "" {
+		t.Errorf("Build() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -75,20 +105,45 @@ func TestBuild_dedupesByTypeClassID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	count := 0
-	for _, n := range g.Nodes {
-		if n.Type == "postgres" {
-			count++
-		}
-	}
-	if count != 1 {
-		t.Fatalf("expected 1 postgres node, got %d", count)
-	}
-	// Both workloads alias the same node.
 	postgresKey := NodeKey("postgres", v1.DefaultClass, "shared-db")
-	n := g.Nodes[postgresKey]
-	if len(n.Aliases) != 2 {
-		t.Errorf("expected 2 aliases, got %v", n.Aliases)
+	want := &Graph{
+		Nodes: map[string]*Node{
+			NodeKey("workload", v1.DefaultClass, "a"): {
+				Key:     NodeKey("workload", v1.DefaultClass, "a"),
+				Type:    "workload",
+				Class:   v1.DefaultClass,
+				ID:      "a",
+				Aliases: []string{"workloads.a"},
+				Edges:   []string{postgresKey},
+				Status:  "pending",
+			},
+			NodeKey("workload", v1.DefaultClass, "b"): {
+				Key:     NodeKey("workload", v1.DefaultClass, "b"),
+				Type:    "workload",
+				Class:   v1.DefaultClass,
+				ID:      "b",
+				Aliases: []string{"workloads.b"},
+				Edges:   []string{postgresKey},
+				Status:  "pending",
+			},
+			postgresKey: {
+				Key:     postgresKey,
+				Type:    "postgres",
+				Class:   v1.DefaultClass,
+				ID:      "shared-db",
+				Aliases: []string{"workloads.a.db", "workloads.b.db"},
+				Status:  "pending",
+			},
+		},
+		AliasIndex: map[string]string{
+			"workloads.a":    NodeKey("workload", v1.DefaultClass, "a"),
+			"workloads.a.db": postgresKey,
+			"workloads.b":    NodeKey("workload", v1.DefaultClass, "b"),
+			"workloads.b.db": postgresKey,
+		},
+	}
+	if diff := graphDiff(want, g); diff != "" {
+		t.Errorf("Build() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -109,12 +164,44 @@ func TestBuild_moduleDependenciesExpanded(t *testing.T) {
 		t.Fatal(err)
 	}
 	netKey := NodeKey("docker-network", v1.DefaultClass, "db1-net")
-	if _, ok := g.Nodes[netKey]; !ok {
-		t.Fatalf("expected docker-network node %s, got %v", netKey, mapKeys(g.Nodes))
-	}
 	dbKey := NodeKey("postgres", v1.DefaultClass, "db1")
-	if !contains(g.Nodes[dbKey].Edges, netKey) {
-		t.Errorf("expected db to depend on net; edges: %v", g.Nodes[dbKey].Edges)
+	workloadKey := NodeKey("workload", v1.DefaultClass, "a")
+	want := &Graph{
+		Nodes: map[string]*Node{
+			workloadKey: {
+				Key:     workloadKey,
+				Type:    "workload",
+				Class:   v1.DefaultClass,
+				ID:      "a",
+				Aliases: []string{"workloads.a"},
+				Edges:   []string{dbKey},
+				Status:  "pending",
+			},
+			dbKey: {
+				Key:      dbKey,
+				Type:     "postgres",
+				Class:    v1.DefaultClass,
+				ID:       "db1",
+				Aliases:  []string{"workloads.a.db"},
+				Edges:    []string{netKey},
+				ModuleID: "postgres-docker",
+				Status:   "pending",
+			},
+			netKey: {
+				Key:    netKey,
+				Type:   "docker-network",
+				Class:  v1.DefaultClass,
+				ID:     "db1-net",
+				Status: "pending",
+			},
+		},
+		AliasIndex: map[string]string{
+			"workloads.a":    workloadKey,
+			"workloads.a.db": dbKey,
+		},
+	}
+	if diff := graphDiff(want, g); diff != "" {
+		t.Errorf("Build() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -130,12 +217,13 @@ func TestTopoSort_dependenciesBeforeDependents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(out) != 3 || out[0].Key != "a" || out[1].Key != "b" || out[2].Key != "c" {
-		var ks []string
-		for _, n := range out {
-			ks = append(ks, n.Key)
-		}
-		t.Fatalf("got order %v want a,b,c", ks)
+	var got []string
+	for _, n := range out {
+		got = append(got, n.Key)
+	}
+	want := []string{"a", "b", "c"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("TopoSort() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -223,10 +311,8 @@ func TestResolveID(t *testing.T) {
 	}
 }
 
-func mapKeys[V any](m map[string]V) []string {
-	ks := make([]string, 0, len(m))
-	for k := range m {
-		ks = append(ks, k)
-	}
-	return ks
+func graphDiff(want, got *Graph) string {
+	return cmp.Diff(want, got, cmpopts.SortSlices(func(a, b string) bool {
+		return a < b
+	}))
 }

--- a/internal/manifest/manifest_test.go
+++ b/internal/manifest/manifest_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
 )
 
 func writeTemp(t *testing.T, content string) string {
@@ -39,8 +42,30 @@ shared:
 	if err != nil {
 		t.Fatal(err)
 	}
-	if m.Metadata.Name != "my-app" || m.Workloads["api"].Resources["db"].Type != "postgres" {
-		t.Errorf("got %+v", m)
+	want := &v1.Manifest{
+		APIVersion: v1.APIVersion,
+		Kind:       v1.KindApplication,
+		Metadata: v1.ManifestMetadata{
+			Name:    "my-app",
+			Project: "demo",
+		},
+		Workloads: map[string]v1.Workload{
+			"api": {
+				Type: "workload",
+				Params: map[string]any{
+					"image": "hello:latest",
+				},
+				Resources: map[string]v1.ResourceRef{
+					"db": {Type: "postgres"},
+				},
+			},
+		},
+		Shared: map[string]v1.ResourceRef{
+			"bucket": {Type: "s3-bucket"},
+		},
+	}
+	if diff := cmp.Diff(want, m); diff != "" {
+		t.Errorf("Load() mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/internal/match/match.go
+++ b/internal/match/match.go
@@ -34,6 +34,14 @@ const (
 // Module returns the best-matching module ID for the given resource type and
 // context. Returns ErrNoMatch if no rule applies.
 func Module(rules []v1.ModuleRule, ctx Context) (string, error) {
+	rule, err := moduleRule(rules, ctx)
+	if err != nil {
+		return "", err
+	}
+	return rule.ModuleID, nil
+}
+
+func moduleRule(rules []v1.ModuleRule, ctx Context) (v1.ModuleRule, error) {
 	type scored struct {
 		rule  v1.ModuleRule
 		score int
@@ -56,15 +64,23 @@ func Module(rules []v1.ModuleRule, ctx Context) (string, error) {
 		}
 	}
 	if len(best) == 0 {
-		return "", fmt.Errorf("%w: no module rule matched resource_type=%s ctx=%+v",
+		return v1.ModuleRule{}, fmt.Errorf("%w: no module rule matched resource_type=%s ctx=%+v",
 			ErrNoMatch, ctx.ResourceType, ctx)
 	}
 	sort.Slice(best, func(i, j int) bool { return best[i].rule.ID < best[j].rule.ID })
-	return best[0].rule.ModuleID, nil
+	return best[0].rule, nil
 }
 
 // Runner returns the best-matching runner ID for the given context.
 func Runner(rules []v1.RunnerRule, ctx Context) (string, error) {
+	rule, err := runnerRule(rules, ctx)
+	if err != nil {
+		return "", err
+	}
+	return rule.RunnerID, nil
+}
+
+func runnerRule(rules []v1.RunnerRule, ctx Context) (v1.RunnerRule, error) {
 	type scored struct {
 		rule  v1.RunnerRule
 		score int
@@ -84,10 +100,10 @@ func Runner(rules []v1.RunnerRule, ctx Context) (string, error) {
 		}
 	}
 	if len(best) == 0 {
-		return "", fmt.Errorf("%w: no runner rule matched ctx=%+v", ErrNoMatch, ctx)
+		return v1.RunnerRule{}, fmt.Errorf("%w: no runner rule matched ctx=%+v", ErrNoMatch, ctx)
 	}
 	sort.Slice(best, func(i, j int) bool { return best[i].rule.ID < best[j].rule.ID })
-	return best[0].rule.RunnerID, nil
+	return best[0].rule, nil
 }
 
 func scoreModuleRule(r v1.ModuleRule, c Context) (int, bool) {

--- a/internal/match/match_test.go
+++ b/internal/match/match_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
 )
 
@@ -11,12 +12,13 @@ func TestModule_emptyRuleIsCatchAll(t *testing.T) {
 	rules := []v1.ModuleRule{
 		{ID: "catchall", ResourceType: "postgres", ModuleID: "postgres-default"},
 	}
-	got, err := Module(rules, Context{ResourceType: "postgres", EnvTypeID: "any"})
+	got, err := moduleRule(rules, Context{ResourceType: "postgres", EnvTypeID: "any"})
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if got != "postgres-default" {
-		t.Fatalf("got %q", got)
+	want := v1.ModuleRule{ID: "catchall", ResourceType: "postgres", ModuleID: "postgres-default"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("moduleRule() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -27,12 +29,13 @@ func TestModule_higherSpecificityWins(t *testing.T) {
 		{ID: "byProject", ResourceType: "postgres", ModuleID: "by-project", ProjectID: "demo"},
 	}
 	// byProject has weight 2, byEnvType has weight 1, catchall has 0.
-	got, err := Module(rules, Context{ResourceType: "postgres", ProjectID: "demo", EnvTypeID: "production"})
+	got, err := moduleRule(rules, Context{ResourceType: "postgres", ProjectID: "demo", EnvTypeID: "production"})
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if got != "by-project" {
-		t.Fatalf("got %q want by-project", got)
+	want := v1.ModuleRule{ID: "byProject", ResourceType: "postgres", ModuleID: "by-project", ProjectID: "demo"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("moduleRule() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -43,15 +46,16 @@ func TestModule_resourceClassDominates(t *testing.T) {
 		{ID: "byClass", ResourceType: "postgres", ModuleID: "class", ResourceClass: "premium"},
 	}
 	// byEverything = 1+2+4+8 = 15. byClass = 16. byClass wins.
-	got, err := Module(rules, Context{
+	got, err := moduleRule(rules, Context{
 		ResourceType: "postgres", EnvTypeID: "production", ProjectID: "demo",
 		EnvID: "prod", ResourceID: "db", ResourceClass: "premium",
 	})
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if got != "class" {
-		t.Fatalf("got %q want class", got)
+	want := v1.ModuleRule{ID: "byClass", ResourceType: "postgres", ModuleID: "class", ResourceClass: "premium"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("moduleRule() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -80,12 +84,13 @@ func TestModule_tieBreakByID(t *testing.T) {
 		{ID: "z-rule", ResourceType: "postgres", ModuleID: "z", EnvTypeID: "prod"},
 		{ID: "a-rule", ResourceType: "postgres", ModuleID: "a", EnvTypeID: "prod"},
 	}
-	got, err := Module(rules, Context{ResourceType: "postgres", EnvTypeID: "prod"})
+	got, err := moduleRule(rules, Context{ResourceType: "postgres", EnvTypeID: "prod"})
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if got != "a" {
-		t.Fatalf("got %q want a (lex tie-break)", got)
+	want := v1.ModuleRule{ID: "a-rule", ResourceType: "postgres", ModuleID: "a", EnvTypeID: "prod"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("moduleRule() mismatch (-want +got):\n%s", diff)
 	}
 }
 
@@ -96,11 +101,12 @@ func TestRunner_specificityOrder(t *testing.T) {
 		{ID: "byProject", RunnerID: "r-project", ProjectID: "demo"},
 		{ID: "both", RunnerID: "r-both", ProjectID: "demo", EnvTypeID: "production"},
 	}
-	got, err := Runner(rules, Context{ProjectID: "demo", EnvTypeID: "production"})
+	got, err := runnerRule(rules, Context{ProjectID: "demo", EnvTypeID: "production"})
 	if err != nil {
 		t.Fatalf("unexpected: %v", err)
 	}
-	if got != "r-both" {
-		t.Fatalf("got %q want r-both", got)
+	want := v1.RunnerRule{ID: "both", RunnerID: "r-both", ProjectID: "demo", EnvTypeID: "production"}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("runnerRule() mismatch (-want +got):\n%s", diff)
 	}
 }


### PR DESCRIPTION
## Summary
- add google/go-cmp as an allowed test diff dependency
- convert manifest, graph, and match tests to cmp.Diff comparisons
- fix merged graph aliases so AliasIndex stays complete
- document cmp.Diff guidance in CLAUDE.md and the testing skill

Closes #16

## Verification
- go test ./internal/manifest ./internal/graph ./internal/match
- go test ./...
- git diff --check