### PR TITLE
Add get tf deployment rendering

### DIFF
--- a/cmd/openporch/cmd_get.go
+++ b/cmd/openporch/cmd_get.go
@@ -5,11 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/krbrudeli/openporch/internal/config"
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/graph"
 	"github.com/krbrudeli/openporch/internal/store/db"
 )
 
@@ -18,7 +24,7 @@ func newGetCmd() *cobra.Command {
 		Use:   "get",
 		Short: "Read deployment history",
 	}
-	cmd.AddCommand(newGetDeploymentsCmd(), newGetDeploymentCmd())
+	cmd.AddCommand(newGetDeploymentsCmd(), newGetDeploymentCmd(), newGetTFCmd())
 	return cmd
 }
 
@@ -126,6 +132,70 @@ func newGetDeploymentCmd() *cobra.Command {
 	return cmd
 }
 
+func newGetTFCmd() *cobra.Command {
+	var (
+		platformDir string
+		outDir      string
+		stateRoot   string
+	)
+	cmd := &cobra.Command{
+		Use:   "tf <deployment-id>",
+		Short: "Render saved deployment Terraform/OpenTofu HCL",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			d, err := db.Open(stateRoot)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+
+			deploymentID := args[0]
+			det, err := db.NewReader(d).GetDeployment(ctx, deploymentID)
+			if err != nil {
+				return err
+			}
+			if det == nil {
+				return fmt.Errorf("deployment %q not found", deploymentID)
+			}
+
+			cfg, err := config.Load(platformDir)
+			if err != nil {
+				return err
+			}
+			g, err := deploy.GraphFromSnapshot(det.GraphJSON)
+			if err != nil {
+				return err
+			}
+			if err := hydrateGraphOutputs(g, det.Resources); err != nil {
+				return err
+			}
+
+			rendered, err := deploy.RenderGraph(deploy.RenderOptions{
+				Platform: cfg, Graph: g,
+				ProjectID: det.Project, EnvID: det.Env, EnvTypeID: det.EnvType,
+				AllowUnresolvedInputs: det.Mode == "plan_only" || det.Status != "succeeded",
+			})
+			if err != nil {
+				return err
+			}
+			if outDir != "" {
+				return writeRenderedTF(outDir, rendered)
+			}
+			printRenderedTF(cmd.OutOrStdout(), rendered)
+			return nil
+		},
+	}
+	cwd, _ := os.Getwd()
+	cmd.Flags().StringVar(&platformDir, "platform", filepath.Join(cwd, "platform"),
+		"directory holding platform config (resource types, modules, rules, providers)")
+	cmd.Flags().StringVar(&outDir, "out", "",
+		"write rendered files under this directory instead of stdout")
+	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
+		"directory under which openporch metadata lives")
+	return cmd
+}
+
 func printDeploymentSummary(out io.Writer, det *db.DeploymentDetail) {
 	fmt.Fprintf(out, "ID:         %s\n", det.ID)
 	fmt.Fprintf(out, "Project:    %s\n", det.Project)
@@ -147,4 +217,72 @@ func printDeploymentSummary(out io.Writer, det *db.DeploymentDetail) {
 		}
 		w.Flush()
 	}
+}
+
+func hydrateGraphOutputs(g *graph.Graph, rows []db.ResourceRow) error {
+	for _, row := range rows {
+		if row.OutputsJSON == "" {
+			continue
+		}
+		n := g.Nodes[row.ResourceKey]
+		if n == nil {
+			return fmt.Errorf("deployment resource %q has outputs but is missing from graph snapshot", row.ResourceKey)
+		}
+		var outputs map[string]any
+		if err := json.Unmarshal([]byte(row.OutputsJSON), &outputs); err != nil {
+			return fmt.Errorf("deployment resource %q outputs are invalid JSON: %w", row.ResourceKey, err)
+		}
+		n.Outputs = outputs
+	}
+	return nil
+}
+
+func printRenderedTF(out io.Writer, rendered []deploy.RenderedResource) {
+	for i, res := range rendered {
+		if i > 0 {
+			fmt.Fprintln(out)
+		}
+		fmt.Fprintf(out, "===== %s/main.tf =====\n", res.Key)
+		fmt.Fprint(out, res.HCL)
+		if !strings.HasSuffix(res.HCL, "\n") {
+			fmt.Fprintln(out)
+		}
+	}
+}
+
+func writeRenderedTF(root string, rendered []deploy.RenderedResource) error {
+	for _, res := range rendered {
+		dir := filepath.Join(root, tfResourceDirName(res.Key))
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("get tf: mkdir %s: %w", dir, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "main.tf"), []byte(res.HCL), 0o644); err != nil {
+			return fmt.Errorf("get tf: write HCL for %s: %w", res.Key, err)
+		}
+		if res.InlineModuleSource != "" {
+			modDir := filepath.Join(dir, "module")
+			if err := os.MkdirAll(modDir, 0o755); err != nil {
+				return fmt.Errorf("get tf: mkdir module for %s: %w", res.Key, err)
+			}
+			if err := os.WriteFile(filepath.Join(modDir, "main.tf"), []byte(res.InlineModuleSource), 0o644); err != nil {
+				return fmt.Errorf("get tf: write inline module for %s: %w", res.Key, err)
+			}
+		}
+	}
+	return nil
+}
+
+func tfResourceDirName(key string) string {
+	out := strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\':
+			return '_'
+		default:
+			return r
+		}
+	}, key)
+	if out == "" {
+		return "_"
+	}
+	return out
 }

--- a/cmd/openporch/cmd_get_test.go
+++ b/cmd/openporch/cmd_get_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -64,6 +66,110 @@ func mustSeedDB(t *testing.T, stateRoot string) (depID, manifestYAML string) {
 		t.Fatalf("FinishDeployment: %v", err)
 	}
 	return depID, manifestYAML
+}
+
+func mustWriteTFPlatform(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	modDir := filepath.Join(root, "modules", "service")
+	if err := os.MkdirAll(modDir, 0o755); err != nil {
+		t.Fatalf("mkdir module dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(modDir, "main.tf"), []byte(`
+variable "database_url" {
+  type = string
+}
+
+output "url" {
+  value = var.database_url
+}
+`), 0o644); err != nil {
+		t.Fatalf("write module HCL: %v", err)
+	}
+	platform := `
+apiVersion: openporch/v1alpha1
+kind: ResourceType
+id: database
+output_schema:
+  type: object
+  properties:
+    url:
+      type: string
+---
+apiVersion: openporch/v1alpha1
+kind: ResourceType
+id: service
+output_schema:
+  type: object
+  properties:
+    url:
+      type: string
+---
+apiVersion: openporch/v1alpha1
+kind: Module
+id: database-mod
+resource_type: database
+module_source: inline
+module_source_code: |
+  output "url" {
+    value = "postgres://db"
+  }
+---
+apiVersion: openporch/v1alpha1
+kind: Module
+id: service-mod
+resource_type: service
+module_source: ./modules/service
+module_inputs:
+  database_url: ${shared.db.outputs.url}
+`
+	if err := os.WriteFile(filepath.Join(root, "platform.yaml"), []byte(platform), 0o644); err != nil {
+		t.Fatalf("write platform config: %v", err)
+	}
+	return root
+}
+
+func mustSeedTFDeployment(t *testing.T, stateRoot string) string {
+	t.Helper()
+	d, err := db.Open(stateRoot)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+
+	ctx := context.Background()
+	rec := db.NewRecorder(d)
+	depID := "dep-tf123"
+	graphJSON := `{"nodes":[` +
+		`{"key":"database|default|shared.db","type":"database","class":"default","id":"shared.db","module_id":"database-mod","aliases":["shared.db"]},` +
+		`{"key":"service|default|api","type":"service","class":"default","id":"api","module_id":"service-mod","aliases":["workloads.api"],"edges":["database|default|shared.db"]}` +
+		`]}`
+	started := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	if err := rec.StartDeployment(ctx, deploy.DeploymentRecord{
+		ID: depID, Project: "myproj", Env: "dev", EnvType: "local",
+		Mode: "deploy", StartedAt: started,
+		ManifestYAML: "apiVersion: openporch/v1alpha1\nkind: Application\n", GraphJSON: graphJSON,
+	}); err != nil {
+		t.Fatalf("StartDeployment: %v", err)
+	}
+	if err := rec.RecordResource(ctx, depID, deploy.ResourceRecord{
+		ResourceKey: "database|default|shared.db", Type: "database", Class: "default",
+		ID: "shared.db", ModuleID: "database-mod", RunnerID: "local-tofu",
+		Status: "applied", OutputsJSON: `{"url":"postgres://db"}`, LogPath: "/tmp/db.log",
+	}); err != nil {
+		t.Fatalf("RecordResource database: %v", err)
+	}
+	if err := rec.RecordResource(ctx, depID, deploy.ResourceRecord{
+		ResourceKey: "service|default|api", Type: "service", Class: "default",
+		ID: "api", ModuleID: "service-mod", RunnerID: "local-tofu",
+		Status: "applied", OutputsJSON: `{"url":"http://api"}`, LogPath: "/tmp/api.log",
+	}); err != nil {
+		t.Fatalf("RecordResource service: %v", err)
+	}
+	if err := rec.FinishDeployment(ctx, depID, "succeeded", started.Add(2*time.Minute)); err != nil {
+		t.Fatalf("FinishDeployment: %v", err)
+	}
+	return depID
 }
 
 // ---------------------------------------------------------------------------
@@ -344,6 +450,72 @@ func TestGetDeployment_InvalidOutput(t *testing.T) {
 		t.Fatal("expected invalid output format error, got nil")
 	}
 	if !strings.Contains(err.Error(), `unsupported output format "xml"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get tf <deployment-id>
+// ---------------------------------------------------------------------------
+
+func TestGetTF_PrintsRenderedHCL(t *testing.T) {
+	root := t.TempDir()
+	platform := mustWriteTFPlatform(t)
+	depID := mustSeedTFDeployment(t, root)
+
+	out, err := runGet(t, root, "tf", depID, "--platform", platform)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"===== database|default|shared.db/main.tf =====",
+		"===== service|default|api/main.tf =====",
+		`source = "./module"`,
+		`source = "` + filepath.Join(platform, "modules", "service") + `"`,
+		`database_url = "postgres://db"`,
+		`output "url"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+}
+
+func TestGetTF_OutWritesMainTFPerResource(t *testing.T) {
+	root := t.TempDir()
+	platform := mustWriteTFPlatform(t)
+	depID := mustSeedTFDeployment(t, root)
+	outDir := t.TempDir()
+
+	_, err := runGet(t, root, "tf", depID, "--platform", platform, "--out", outDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	serviceMain := filepath.Join(outDir, "service|default|api", "main.tf")
+	b, err := os.ReadFile(serviceMain)
+	if err != nil {
+		t.Fatalf("read service main.tf: %v", err)
+	}
+	if !strings.Contains(string(b), `database_url = "postgres://db"`) {
+		t.Errorf("rendered service HCL missing resolved input:\n%s", string(b))
+	}
+	dbMain := filepath.Join(outDir, "database|default|shared.db", "main.tf")
+	if _, err := os.Stat(dbMain); err != nil {
+		t.Fatalf("database main.tf not written: %v", err)
+	}
+	dbModule := filepath.Join(outDir, "database|default|shared.db", "module", "main.tf")
+	if _, err := os.Stat(dbModule); err != nil {
+		t.Fatalf("inline database module not written: %v", err)
+	}
+}
+
+func TestGetTF_NotFound(t *testing.T) {
+	platform := mustWriteTFPlatform(t)
+	_, err := runGet(t, t.TempDir(), "tf", "no-such-id", "--platform", platform)
+	if err == nil {
+		t.Fatal("expected error for nonexistent deployment ID, got nil")
+	}
+	if !strings.Contains(err.Error(), `deployment "no-such-id" not found`) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -91,6 +91,59 @@ type Result struct {
 	DryRunResources []DryRunResource          // populated when Options.DryRun is true
 }
 
+// RenderedResource is one root OpenTofu module rendered for a graph node.
+type RenderedResource struct {
+	Key                string
+	HCL                string
+	InlineModuleSource string
+}
+
+// RenderOptions drives a render-only pass over an already-resolved graph.
+type RenderOptions struct {
+	Platform  *v1.PlatformConfig
+	Graph     *graph.Graph
+	ProjectID string
+	EnvID     string
+	EnvTypeID string
+	OrgID     string
+
+	// AllowUnresolvedInputs leaves unresolved output placeholders in place.
+	// This matches dry-run/plan-only behavior in Run.
+	AllowUnresolvedInputs bool
+}
+
+// RenderGraph renders root main.tf content for every node in apply order
+// without invoking tofu or mutating deployment state.
+func RenderGraph(o RenderOptions) ([]RenderedResource, error) {
+	if o.Platform == nil {
+		return nil, fmt.Errorf("deploy: platform config is required")
+	}
+	if o.Graph == nil {
+		return nil, fmt.Errorf("deploy: graph is required")
+	}
+	if err := validateParams(o.Graph, o.Platform.Modules); err != nil {
+		return nil, err
+	}
+	ordered, err := o.Graph.TopoSort()
+	if err != nil {
+		return nil, fmt.Errorf("deploy: topo sort: %w", err)
+	}
+	rendered := make([]RenderedResource, 0, len(ordered))
+	for _, n := range ordered {
+		hcl, inlineModuleSrc, _, err := renderNodeHCL(
+			o.Graph, n, o.Platform, o.ProjectID, o.EnvID, o.EnvTypeID, o.OrgID,
+			o.AllowUnresolvedInputs,
+		)
+		if err != nil {
+			return nil, err
+		}
+		rendered = append(rendered, RenderedResource{
+			Key: n.Key, HCL: hcl, InlineModuleSource: inlineModuleSrc,
+		})
+	}
+	return rendered, nil
+}
+
 // envVars implements expr.Vars over os.Getenv with TF_VAR_ prefix. This is
 // the minimum needed to support ${var.NAME} for provider configs.
 type envVars struct{}
@@ -207,66 +260,12 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 	resolved := map[string]map[string]any{}
 	var dryRunResources []DryRunResource
 	for _, n := range ordered {
-		mod := o.Platform.Modules[n.ModuleID]
-		ectx := expr.Context{
-			OrgID: o.OrgID, ProjectID: o.ProjectID, EnvID: o.EnvID,
-			EnvTypeID: o.EnvTypeID, ResType: n.Type, ResClass: n.Class, ResID: n.ID,
-			WorkloadName: workloadFromAliases(n.Aliases),
-		}
-
-		// Merge module_inputs (static) with manifest params (dev-supplied).
-		// Manifest params win on key collisions because the module config
-		// already forbids same-key in inputs+params at validation time.
-		inputs := map[string]any{}
-		for k, v := range mod.ModuleInputs {
-			inputs[k] = v
-		}
-		for k, v := range n.Params {
-			inputs[k] = v
-		}
-		st := stateView{g: g}
-		resolvedInputs, rerr := expr.ResolveAny(inputs, ectx, st, envVars{})
-		if rerr != nil && !errors.Is(rerr, expr.ErrUnresolved) {
-			return nil, fmt.Errorf("deploy: resolve inputs for %s: %w", n.Key, rerr)
-		}
-		if !o.DryRun && !o.PlanOnly && errors.Is(rerr, expr.ErrUnresolved) {
-			return nil, fmt.Errorf("deploy: unresolved placeholder in inputs of %s (likely a missing dependency edge): %w",
-				n.Key, rerr)
-		}
-
-		providers, providerMap, err := assembleProviders(mod, o.Platform.Providers, ectx, st)
+		hcl, inlineModuleSrc, providers, err := renderNodeHCL(
+			g, n, o.Platform, o.ProjectID, o.EnvID, o.EnvTypeID, o.OrgID,
+			o.DryRun || o.PlanOnly,
+		)
 		if err != nil {
-			return nil, fmt.Errorf("deploy: providers for %s: %w", n.Key, err)
-		}
-
-		outNames := outputNamesForType(o.Platform.ResourceTypes[n.Type])
-
-		moduleSource := mod.ModuleSource
-		var inlineModuleSrc string
-		if mod.ModuleSource == "inline" || mod.ModuleSourceCode != "" {
-			inlineModuleSrc = mod.ModuleSourceCode
-			if !o.DryRun {
-				if err := o.Store.WriteInlineModule(o.ProjectID, o.EnvID, n.Key, mod.ModuleSourceCode); err != nil {
-					return nil, err
-				}
-			}
-			moduleSource = "./module"
-		} else {
-			resolved, err := tofu.ResolveSource(mod.ModuleSource, o.Platform.RootDir)
-			if err != nil {
-				return nil, fmt.Errorf("deploy: resolve module source for %s: %w", n.Key, err)
-			}
-			moduleSource = resolved
-		}
-		hcl, err := tofu.Render(tofu.Plan{
-			ModuleSource:    moduleSource,
-			Inputs:          resolvedInputs.(map[string]any),
-			Providers:       providers,
-			ProviderMapping: providerMap,
-			OutputNames:     outNames,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("deploy: render %s: %w", n.Key, err)
+			return nil, err
 		}
 		if o.DryRun {
 			providerTypes := make([]string, 0, len(providers))
@@ -286,6 +285,11 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 			continue
 		}
 
+		if inlineModuleSrc != "" {
+			if err := o.Store.WriteInlineModule(o.ProjectID, o.EnvID, n.Key, inlineModuleSrc); err != nil {
+				return nil, err
+			}
+		}
 		workdir, err := o.Store.WriteRootTF(o.ProjectID, o.EnvID, n.Key, hcl)
 		if err != nil {
 			return nil, err
@@ -391,6 +395,73 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		Outputs:         manifestOutputs,
 		DryRunResources: dryRunResources,
 	}, nil
+}
+
+func renderNodeHCL(
+	g *graph.Graph,
+	n *graph.Node,
+	platform *v1.PlatformConfig,
+	projectID, envID, envTypeID, orgID string,
+	allowUnresolvedInputs bool,
+) (string, string, []tofu.ProviderUsage, error) {
+	mod, ok := platform.Modules[n.ModuleID]
+	if !ok {
+		return "", "", nil, fmt.Errorf("deploy: module %q for %s not found", n.ModuleID, n.Key)
+	}
+	ectx := expr.Context{
+		OrgID: orgID, ProjectID: projectID, EnvID: envID,
+		EnvTypeID: envTypeID, ResType: n.Type, ResClass: n.Class, ResID: n.ID,
+		WorkloadName: workloadFromAliases(n.Aliases),
+	}
+
+	// Merge module_inputs (static) with manifest params (dev-supplied).
+	// Manifest params win on key collisions because the module config
+	// already forbids same-key in inputs+params at validation time.
+	inputs := map[string]any{}
+	for k, v := range mod.ModuleInputs {
+		inputs[k] = v
+	}
+	for k, v := range n.Params {
+		inputs[k] = v
+	}
+	st := stateView{g: g}
+	resolvedInputs, rerr := expr.ResolveAny(inputs, ectx, st, envVars{})
+	if rerr != nil && !errors.Is(rerr, expr.ErrUnresolved) {
+		return "", "", nil, fmt.Errorf("deploy: resolve inputs for %s: %w", n.Key, rerr)
+	}
+	if !allowUnresolvedInputs && errors.Is(rerr, expr.ErrUnresolved) {
+		return "", "", nil, fmt.Errorf("deploy: unresolved placeholder in inputs of %s (likely a missing dependency edge): %w",
+			n.Key, rerr)
+	}
+
+	providers, providerMap, err := assembleProviders(mod, platform.Providers, ectx, st)
+	if err != nil {
+		return "", "", nil, fmt.Errorf("deploy: providers for %s: %w", n.Key, err)
+	}
+
+	moduleSource := mod.ModuleSource
+	var inlineModuleSrc string
+	if mod.ModuleSource == "inline" || mod.ModuleSourceCode != "" {
+		inlineModuleSrc = mod.ModuleSourceCode
+		moduleSource = "./module"
+	} else {
+		resolved, err := tofu.ResolveSource(mod.ModuleSource, platform.RootDir)
+		if err != nil {
+			return "", "", nil, fmt.Errorf("deploy: resolve module source for %s: %w", n.Key, err)
+		}
+		moduleSource = resolved
+	}
+	hcl, err := tofu.Render(tofu.Plan{
+		ModuleSource:    moduleSource,
+		Inputs:          resolvedInputs.(map[string]any),
+		Providers:       providers,
+		ProviderMapping: providerMap,
+		OutputNames:     outputNamesForType(platform.ResourceTypes[n.Type]),
+	})
+	if err != nil {
+		return "", "", nil, fmt.Errorf("deploy: render %s: %w", n.Key, err)
+	}
+	return hcl, inlineModuleSrc, providers, nil
 }
 
 func validateParams(g *graph.Graph, modules map[string]v1.Module) error {

--- a/internal/deploy/deploy_record.go
+++ b/internal/deploy/deploy_record.go
@@ -2,6 +2,8 @@ package deploy
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/krbrudeli/openporch/internal/graph"
 )
@@ -44,4 +46,37 @@ func serializeGraph(g *graph.Graph) (string, error) {
 		return "", err
 	}
 	return string(b), nil
+}
+
+// GraphFromSnapshot reconstructs a deployment graph from the JSON stored in
+// deployment_graph.graph_json.
+func GraphFromSnapshot(snapshot string) (*graph.Graph, error) {
+	if strings.TrimSpace(snapshot) == "" {
+		return nil, fmt.Errorf("deploy: empty graph snapshot")
+	}
+	var snap graphSnapshot
+	if err := json.Unmarshal([]byte(snapshot), &snap); err != nil {
+		return nil, fmt.Errorf("deploy: parse graph snapshot: %w", err)
+	}
+	g := graph.New()
+	for _, n := range snap.Nodes {
+		node := &graph.Node{
+			Key:      n.Key,
+			Type:     n.Type,
+			Class:    n.Class,
+			ID:       n.ID,
+			ModuleID: n.ModuleID,
+			Aliases:  n.Aliases,
+			Edges:    n.Edges,
+			Params:   n.Params,
+			Status:   "pending",
+		}
+		if node.Params == nil {
+			node.Params = map[string]any{}
+		}
+		if err := g.AddOrMerge(node); err != nil {
+			return nil, fmt.Errorf("deploy: graph snapshot node %q: %w", n.Key, err)
+		}
+	}
+	return g, nil
 }

--- a/internal/store/db/reader.go
+++ b/internal/store/db/reader.go
@@ -43,6 +43,7 @@ type DeploymentDetail struct {
 	FinishedAt   string        `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
 	Mode         string        `json:"mode" yaml:"mode"`
 	ManifestYAML string        `json:"manifest_yaml" yaml:"manifest_yaml"`
+	GraphJSON    string        `json:"graph_json" yaml:"graph_json"`
 	Resources    []ResourceRow `json:"resources" yaml:"resources"`
 }
 
@@ -105,6 +106,12 @@ func (r *Reader) GetDeployment(ctx context.Context, id string) (*DeploymentDetai
 		`SELECT manifest_yaml FROM deployment_manifest WHERE deployment_id = ?`, id)
 	if err := mRow.Scan(&d.ManifestYAML); err != nil && err != sql.ErrNoRows {
 		return nil, fmt.Errorf("db: get deployment manifest: %w", err)
+	}
+
+	gRow := r.db.QueryRowContext(ctx,
+		`SELECT graph_json FROM deployment_graph WHERE deployment_id = ?`, id)
+	if err := gRow.Scan(&d.GraphJSON); err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("db: get deployment graph: %w", err)
 	}
 
 	resRows, err := r.db.QueryContext(ctx,


### PR DESCRIPTION
## Summary
- add `opo get tf <deployment-id>` for render-only HCL inspection from deployment history
- reconstruct saved deployment graphs, hydrate persisted outputs, and reuse deploy rendering without running tofu
- support `--out <dir>` with one `main.tf` per resource plus inline module files

Fixes #11

## Verification
- `go test ./...`
- `go test -tags=integration -timeout=10m ./internal/deploy/...`