### PR TITLE
Replace substring assertions in tofu render tests with golden files

### DIFF
--- a/internal/tofu/render_test.go
+++ b/internal/tofu/render_test.go
@@ -1,15 +1,47 @@
 package tofu
 
 import (
+	"flag"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/hcl/v2/hclparse"
 )
 
+var update = flag.Bool("update", false, "update golden files")
+
+// goldenTest renders p, optionally writes the result to testdata/<name>.golden.hcl
+// when -update is set, then asserts byte-for-byte equality with the golden file.
+func goldenTest(t *testing.T, p Plan, name string) {
+	t.Helper()
+	got, err := Render(p)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	goldenPath := filepath.Join("testdata", name+".golden.hcl")
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(goldenPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(string(want), got); diff != "" {
+		t.Errorf("rendered output mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestRender_smoke(t *testing.T) {
 	t.Parallel()
-	p := Plan{
+	goldenTest(t, Plan{
 		ModuleSource: "./module",
 		Inputs: map[string]any{
 			"image": "myorg/api:1.0",
@@ -24,37 +56,52 @@ func TestRender_smoke(t *testing.T) {
 		},
 		ProviderMapping: map[string]string{"docker": "docker.default"},
 		OutputNames:     []string{"url", "host"},
-	}
-	out, err := Render(p)
-	if err != nil {
-		t.Fatal(err)
-	}
-	for _, want := range []string{
-		`terraform {`,
-		`required_providers {`,
-		`docker = {`,
-		`source = "kreuzwerker/docker"`,
-		`version = "~> 3.0"`,
-		`provider "docker" {`,
-		`alias = "default"`,
-		`module "main" {`,
-		`source = "./module"`,
-		`providers = {`,
-		`docker = docker.default`,
-		`image = "myorg/api:1.0"`,
-		`env = {`,
-		`DATABASE_URL = "postgres://x"`,
-		`PORT = 8080`,
-		`output "host"`,
-		`output "url"`,
-		`value = module.main.url`,
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("rendered output missing %q.\nfull:\n%s", want, out)
-		}
-	}
+	}, "render_smoke")
 }
 
+func TestRender_noProviders(t *testing.T) {
+	t.Parallel()
+	goldenTest(t, Plan{
+		ModuleSource: "./module",
+		Inputs:       map[string]any{"name": "api"},
+		OutputNames:  []string{"url"},
+	}, "render_no_providers")
+}
+
+func TestRender_multipleProviders(t *testing.T) {
+	t.Parallel()
+	goldenTest(t, Plan{
+		ModuleSource: "./mod",
+		Providers: []ProviderUsage{
+			{Type: "aws", Source: "hashicorp/aws", Version: "~> 5.0",
+				Alias: "us_east_1", Config: map[string]any{"region": "us-east-1"}},
+			{Type: "docker", Source: "kreuzwerker/docker", Version: "~> 3.0",
+				Alias: "default", Config: map[string]any{"host": "unix:///var/run/docker.sock"}},
+		},
+		ProviderMapping: map[string]string{
+			"aws":    "aws.us_east_1",
+			"docker": "docker.default",
+		},
+		OutputNames: []string{"endpoint"},
+	}, "render_multiple_providers")
+}
+
+func TestRender_envNonIdentKeys(t *testing.T) {
+	t.Parallel()
+	goldenTest(t, Plan{
+		ModuleSource: "./module",
+		Inputs: map[string]any{
+			"env": map[string]any{
+				"with-hyphen": "value1",
+				"with space":  "value2",
+				"NORMAL_KEY":  "value3",
+			},
+		},
+	}, "render_env_non_ident_keys")
+}
+
+// TestHclValue_quotesNonIdentKeys checks the quoting property directly — a
+// golden diff wouldn't make it obvious that quoting is the invariant being tested.
 func TestHclValue_quotesNonIdentKeys(t *testing.T) {
 	t.Parallel()
 	got := hclValue(map[string]any{"with space": "v"}, "")

--- a/internal/tofu/testdata/render_env_non_ident_keys.golden.hcl
+++ b/internal/tofu/testdata/render_env_non_ident_keys.golden.hcl
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+  }
+}
+
+module "main" {
+  source = "./module"
+
+  env = {
+    NORMAL_KEY = "value3"
+    "with space" = "value2"
+    with-hyphen = "value1"
+  }
+}
+

--- a/internal/tofu/testdata/render_multiple_providers.golden.hcl
+++ b/internal/tofu/testdata/render_multiple_providers.golden.hcl
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    docker = {
+      source = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  alias = "us_east_1"
+  region = "us-east-1"
+}
+
+provider "docker" {
+  alias = "default"
+  host = "unix:///var/run/docker.sock"
+}
+
+module "main" {
+  source = "./mod"
+
+  providers = {
+    aws = aws.us_east_1
+    docker = docker.default
+  }
+}
+
+output "endpoint" {
+  value = module.main.endpoint
+}
+

--- a/internal/tofu/testdata/render_no_providers.golden.hcl
+++ b/internal/tofu/testdata/render_no_providers.golden.hcl
@@ -1,0 +1,15 @@
+terraform {
+  required_providers {
+  }
+}
+
+module "main" {
+  source = "./module"
+
+  name = "api"
+}
+
+output "url" {
+  value = module.main.url
+}
+

--- a/internal/tofu/testdata/render_smoke.golden.hcl
+++ b/internal/tofu/testdata/render_smoke.golden.hcl
@@ -1,0 +1,36 @@
+terraform {
+  required_providers {
+    docker = {
+      source = "kreuzwerker/docker"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "docker" {
+  alias = "default"
+  host = "unix:///var/run/docker.sock"
+}
+
+module "main" {
+  source = "./module"
+
+  providers = {
+    docker = docker.default
+  }
+
+  env = {
+    DATABASE_URL = "postgres://x"
+    PORT = 8080
+  }
+  image = "myorg/api:1.0"
+}
+
+output "host" {
+  value = module.main.host
+}
+
+output "url" {
+  value = module.main.url
+}
+


### PR DESCRIPTION
## Summary

- Replaces the 18 `strings.Contains` checks in `TestRender_smoke` with four golden-file tests (smoke, no-providers, multiple-providers, env with non-ident keys) gated on a `-update` flag
- Failures now produce a unified `cmp.Diff` output that names the exact offending line rather than just the missing substring
- Keeps narrow property tests (`parsesAsValidHCL`, `deterministicOrder`, `quotesNonIdentKeys`) where a golden diff would not make the tested invariant obvious
- `go-cmp` was already present in `go.mod`; no new dependencies added

## Test plan

- [ ] `go test -race -count=1 ./internal/tofu` passes
- [ ] `go test ./internal/tofu -update` regenerates the golden files; resulting git diff is human-readable HCL
- [ ] Deliberately adding a stray attribute in `render.go` produces a unified diff in the failure output naming the offending line

Closes #14

https://claude.ai/code/session_018XsA1CJ2LZxvE3Pkvn455T

---
_Generated by [Claude Code](https://claude.ai/code/session_018XsA1CJ2LZxvE3Pkvn455T)_