### PR TITLE
Add active resources tracking for deployments

### DIFF
--- a/cmd/openporch/cmd_get.go
+++ b/cmd/openporch/cmd_get.go
@@ -24,7 +24,7 @@ func newGetCmd() *cobra.Command {
 		Use:   "get",
 		Short: "Read deployment history",
 	}
-	cmd.AddCommand(newGetDeploymentsCmd(), newGetDeploymentCmd(), newGetTFCmd())
+	cmd.AddCommand(newGetDeploymentsCmd(), newGetDeploymentCmd(), newGetTFCmd(), newGetActiveResourcesCmd())
 	return cmd
 }
 
@@ -285,4 +285,57 @@ func tfResourceDirName(key string) string {
 		return "_"
 	}
 	return out
+}
+
+func newGetActiveResourcesCmd() *cobra.Command {
+	var (
+		output    string
+		stateRoot string
+	)
+	cmd := &cobra.Command{
+		Use:   "active-resources <project> <env>",
+		Short: "List active resources for a (project, env) pair",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			project, env := args[0], args[1]
+			ctx := context.Background()
+			d, err := db.Open(stateRoot)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+
+			rows, err := db.NewReader(d).ListActiveResources(ctx, project, env)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			switch output {
+			case "json":
+				enc := json.NewEncoder(out)
+				enc.SetIndent("", "  ")
+				return enc.Encode(rows)
+			case "yaml":
+				enc := yaml.NewEncoder(out)
+				enc.SetIndent(2)
+				return enc.Encode(rows)
+			case "table", "":
+				w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+				fmt.Fprintln(w, "KEY\tTYPE\tCLASS\tID\tMODULE\tDEPLOYMENT\tUPDATED_AT")
+				for _, row := range rows {
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+						row.ResourceKey, row.Type, row.Class, row.ID,
+						row.ModuleID, row.DeploymentID, row.UpdatedAt)
+				}
+				return w.Flush()
+			default:
+				return fmt.Errorf("unsupported output format %q (want table, yaml, or json)", output)
+			}
+		},
+	}
+	cmd.Flags().StringVarP(&output, "output", "o", "table", "output format: table, yaml, json")
+	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
+		"directory under which openporch metadata lives")
+	return cmd
 }

--- a/cmd/openporch/cmd_get_test.go
+++ b/cmd/openporch/cmd_get_test.go
@@ -519,3 +519,145 @@ func TestGetTF_NotFound(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// mustSeedActiveResources seeds active_resources directly via the recorder.
+// ---------------------------------------------------------------------------
+
+func mustSeedActiveResources(t *testing.T, stateRoot string) {
+	t.Helper()
+	d, err := db.Open(stateRoot)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+	rec := db.NewRecorder(d)
+	ctx := context.Background()
+	if err := rec.SetActiveResources(ctx, "myproj", "dev", "dep-abc123", []deploy.ActiveResourceRecord{
+		{
+			ResourceKey: "postgres|default|db", Type: "postgres", Class: "default",
+			ID: "db", ModuleID: "mod-pg", OutputsJSON: `{"url":"postgres://db"}`,
+		},
+		{
+			ResourceKey: "service|default|api", Type: "service", Class: "default",
+			ID: "api", ModuleID: "mod-svc", OutputsJSON: `{"url":"http://api"}`,
+		},
+	}); err != nil {
+		t.Fatalf("SetActiveResources: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// get active-resources
+// ---------------------------------------------------------------------------
+
+func TestGetActiveResources_EmptyTable(t *testing.T) {
+	t.Parallel()
+	out, err := runGet(t, t.TempDir(), "active-resources", "myproj", "dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "KEY") || !strings.Contains(out, "TYPE") {
+		t.Errorf("expected table header in output, got:\n%s", out)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected 1 line (header only), got %d:\n%s", len(lines), out)
+	}
+}
+
+func TestGetActiveResources_ListsResources(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustSeedActiveResources(t, root)
+
+	out, err := runGet(t, root, "active-resources", "myproj", "dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, want := range []string{"service|default|api", "postgres|default|db", "dep-abc123"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output:\n%s", want, out)
+		}
+	}
+	// rows ordered by resource_key: postgres first
+	posPostgres := strings.Index(out, "postgres|default|db")
+	posService := strings.Index(out, "service|default|api")
+	if posPostgres > posService {
+		t.Errorf("expected postgres row before service row in output:\n%s", out)
+	}
+}
+
+func TestGetActiveResources_JSONOutput(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustSeedActiveResources(t, root)
+
+	out, err := runGet(t, root, "active-resources", "myproj", "dev", "-o", "json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var rows []db.ActiveResourceRow
+	if err := json.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, out)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0].ResourceKey != "postgres|default|db" {
+		t.Errorf("rows[0].ResourceKey = %q, want postgres|default|db", rows[0].ResourceKey)
+	}
+	if rows[0].OutputsJSON != `{"url":"postgres://db"}` {
+		t.Errorf("rows[0].OutputsJSON = %q", rows[0].OutputsJSON)
+	}
+	if rows[1].ResourceKey != "service|default|api" {
+		t.Errorf("rows[1].ResourceKey = %q, want service|default|api", rows[1].ResourceKey)
+	}
+	if rows[1].DeploymentID != "dep-abc123" {
+		t.Errorf("rows[1].DeploymentID = %q, want dep-abc123", rows[1].DeploymentID)
+	}
+}
+
+func TestGetActiveResources_YAMLOutput(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustSeedActiveResources(t, root)
+
+	out, err := runGet(t, root, "active-resources", "myproj", "dev", "-o", "yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var rows []db.ActiveResourceRow
+	if err := yaml.Unmarshal([]byte(out), &rows); err != nil {
+		t.Fatalf("output is not valid YAML: %v\n%s", err, out)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+}
+
+func TestGetActiveResources_WrongProject(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	mustSeedActiveResources(t, root)
+
+	out, err := runGet(t, root, "active-resources", "other-proj", "dev")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	if len(lines) != 1 {
+		t.Errorf("expected header only for nonexistent project, got %d lines:\n%s", len(lines), out)
+	}
+}
+
+func TestGetActiveResources_InvalidOutput(t *testing.T) {
+	t.Parallel()
+	_, err := runGet(t, t.TempDir(), "active-resources", "p", "e", "-o", "xml")
+	if err == nil {
+		t.Fatal("expected invalid output format error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unsupported output format "xml"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -368,6 +368,27 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		}
 	}
 
+	// After a successful (non-dry-run, non-plan-only) apply pass, persist the
+	// current active resource set for this (project, env).
+	if o.Recorder != nil && !o.DryRun && !o.PlanOnly {
+		activeRecs := make([]ActiveResourceRecord, 0, len(ordered))
+		for _, n := range ordered {
+			if n.Status != "applied" {
+				continue
+			}
+			outputsJSON := ""
+			if out, ok := resolved[n.Key]; ok {
+				b, _ := json.Marshal(out)
+				outputsJSON = string(b)
+			}
+			activeRecs = append(activeRecs, ActiveResourceRecord{
+				ResourceKey: n.Key, Type: n.Type, Class: n.Class, ID: n.ID,
+				ModuleID: n.ModuleID, OutputsJSON: outputsJSON,
+			})
+		}
+		_ = o.Recorder.SetActiveResources(ctx, o.ProjectID, o.EnvID, o.DeploymentID, activeRecs)
+	}
+
 	// Resolve manifest-level outputs. In dry-run, cross-resource placeholders
 	// can't be resolved (no outputs available), so ErrUnresolved is tolerated.
 	manifestOutputs := map[string]string{}

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -27,6 +27,10 @@ func (c *captureRecorder) RecordResource(_ context.Context, _ string, r Resource
 func (c *captureRecorder) FinishDeployment(_ context.Context, _ string, _ string, _ time.Time) error {
 	return nil
 }
+func (c *captureRecorder) SetActiveResources(_ context.Context, _, _, _ string, _ []ActiveResourceRecord) error {
+	return nil
+}
+func (c *captureRecorder) ClearActiveResources(_ context.Context, _, _ string) error { return nil }
 
 // captureFinish captures every FinishDeployment status.
 type captureFinish struct {
@@ -56,6 +60,12 @@ func (s *startCapturingRecorder) RecordResource(_ context.Context, _ string, _ R
 func (s *startCapturingRecorder) FinishDeployment(_ context.Context, _ string, _ string, _ time.Time) error {
 	return nil
 }
+func (s *startCapturingRecorder) SetActiveResources(_ context.Context, _, _, _ string, _ []ActiveResourceRecord) error {
+	return nil
+}
+func (s *startCapturingRecorder) ClearActiveResources(_ context.Context, _, _ string) error {
+	return nil
+}
 
 // recorderFunc is a Recorder backed by function fields for precise event capture.
 type recorderFunc struct {
@@ -82,6 +92,10 @@ func (r *recorderFunc) FinishDeployment(_ context.Context, _ string, status stri
 	}
 	return nil
 }
+func (r *recorderFunc) SetActiveResources(_ context.Context, _, _, _ string, _ []ActiveResourceRecord) error {
+	return nil
+}
+func (r *recorderFunc) ClearActiveResources(_ context.Context, _, _ string) error { return nil }
 
 // minimalPlatform returns a PlatformConfig with one resource type and one
 // inline module wired up by a catch-all rule. No providers are needed.

--- a/internal/deploy/destroy.go
+++ b/internal/deploy/destroy.go
@@ -119,6 +119,9 @@ func Destroy(ctx context.Context, o DestroyOptions) (*DestroyResult, error) {
 		if firstErr != nil {
 			status = "failed"
 		}
+		if firstErr == nil {
+			_ = o.Recorder.ClearActiveResources(ctx, o.ProjectID, o.EnvID)
+		}
 		_ = o.Recorder.FinishDeployment(ctx, o.DeploymentID, status, time.Now().UTC())
 	}
 	return res, firstErr

--- a/internal/deploy/recorder.go
+++ b/internal/deploy/recorder.go
@@ -17,6 +17,24 @@ type Recorder interface {
 	StartDeployment(ctx context.Context, d DeploymentRecord) error
 	RecordResource(ctx context.Context, deploymentID string, r ResourceRecord) error
 	FinishDeployment(ctx context.Context, deploymentID string, status string, finishedAt time.Time) error
+	// SetActiveResources atomically replaces the active resource set for
+	// (project, env) with the provided slice, tagging each row with
+	// deploymentID. Resources previously active but absent from the new
+	// slice are removed.
+	SetActiveResources(ctx context.Context, project, env, deploymentID string, resources []ActiveResourceRecord) error
+	// ClearActiveResources removes all active resources for (project, env).
+	ClearActiveResources(ctx context.Context, project, env string) error
+}
+
+// ActiveResourceRecord captures the identity and outputs of one resource
+// in the live set for an environment.
+type ActiveResourceRecord struct {
+	ResourceKey string
+	Type        string
+	Class       string
+	ID          string
+	ModuleID    string
+	OutputsJSON string
 }
 
 // DeploymentRecord is the snapshot written when a deployment starts.

--- a/internal/store/db/db.go
+++ b/internal/store/db/db.go
@@ -88,6 +88,19 @@ var migrations = []string{
 		graph_json    TEXT NOT NULL
 	);`,
 	`ALTER TABLE deployment_resources ADD COLUMN plan_path TEXT NOT NULL DEFAULT '';`,
+	`CREATE TABLE active_resources (
+		project       TEXT NOT NULL,
+		env           TEXT NOT NULL,
+		resource_key  TEXT NOT NULL,
+		type          TEXT NOT NULL,
+		class         TEXT NOT NULL,
+		id            TEXT NOT NULL,
+		module_id     TEXT NOT NULL,
+		deployment_id TEXT NOT NULL,
+		outputs_json  TEXT,
+		updated_at    TEXT NOT NULL,
+		PRIMARY KEY (project, env, resource_key)
+	);`,
 }
 
 func migrate(db *sql.DB) error {

--- a/internal/store/db/db_test.go
+++ b/internal/store/db/db_test.go
@@ -22,6 +22,7 @@ func TestOpenAppliesSchema(t *testing.T) {
 		"deployment_resources",
 		"deployment_manifest",
 		"deployment_graph",
+		"active_resources",
 		"_schema_version",
 	}
 	for _, name := range expected {
@@ -240,5 +241,162 @@ func TestRecorderDestroyMode(t *testing.T) {
 	}
 	if mode != "destroy" {
 		t.Errorf("mode = %q, want destroy", mode)
+	}
+}
+
+func TestSetActiveResources_UpsertAndReplace(t *testing.T) {
+	t.Parallel()
+	d, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+	rec := NewRecorder(d)
+	rdr := NewReader(d)
+	ctx := context.Background()
+
+	first := []deploy.ActiveResourceRecord{
+		{ResourceKey: "service|default|api", Type: "service", Class: "default", ID: "api", ModuleID: "mod-svc", OutputsJSON: `{"url":"http://x"}`},
+		{ResourceKey: "postgres|default|db", Type: "postgres", Class: "default", ID: "db", ModuleID: "mod-pg"},
+	}
+	if err := rec.SetActiveResources(ctx, "proj", "dev", "dep-1", first); err != nil {
+		t.Fatalf("SetActiveResources (first): %v", err)
+	}
+
+	rows, err := rdr.ListActiveResources(ctx, "proj", "dev")
+	if err != nil {
+		t.Fatalf("ListActiveResources: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows after first set, got %d", len(rows))
+	}
+	// ordered by resource_key: postgres first, then service
+	if rows[0].ResourceKey != "postgres|default|db" {
+		t.Errorf("rows[0].ResourceKey = %q, want postgres|default|db", rows[0].ResourceKey)
+	}
+	if rows[1].ResourceKey != "service|default|api" {
+		t.Errorf("rows[1].ResourceKey = %q, want service|default|api", rows[1].ResourceKey)
+	}
+	if rows[1].OutputsJSON != `{"url":"http://x"}` {
+		t.Errorf("rows[1].OutputsJSON = %q, want {\"url\":\"http://x\"}", rows[1].OutputsJSON)
+	}
+	if rows[1].DeploymentID != "dep-1" {
+		t.Errorf("rows[1].DeploymentID = %q, want dep-1", rows[1].DeploymentID)
+	}
+
+	// Second set: removes postgres, keeps service, changes deployment_id.
+	second := []deploy.ActiveResourceRecord{
+		{ResourceKey: "service|default|api", Type: "service", Class: "default", ID: "api", ModuleID: "mod-svc"},
+	}
+	if err := rec.SetActiveResources(ctx, "proj", "dev", "dep-2", second); err != nil {
+		t.Fatalf("SetActiveResources (second): %v", err)
+	}
+
+	rows, err = rdr.ListActiveResources(ctx, "proj", "dev")
+	if err != nil {
+		t.Fatalf("ListActiveResources after second set: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row after second set, got %d", len(rows))
+	}
+	if rows[0].ResourceKey != "service|default|api" {
+		t.Errorf("rows[0].ResourceKey = %q, want service|default|api", rows[0].ResourceKey)
+	}
+	if rows[0].DeploymentID != "dep-2" {
+		t.Errorf("rows[0].DeploymentID = %q, want dep-2", rows[0].DeploymentID)
+	}
+}
+
+func TestSetActiveResources_IsolatedByProjectEnv(t *testing.T) {
+	t.Parallel()
+	d, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+	rec := NewRecorder(d)
+	rdr := NewReader(d)
+	ctx := context.Background()
+
+	res := []deploy.ActiveResourceRecord{
+		{ResourceKey: "service|default|api", Type: "service", Class: "default", ID: "api", ModuleID: "mod-svc"},
+	}
+	if err := rec.SetActiveResources(ctx, "proj-a", "dev", "dep-a", res); err != nil {
+		t.Fatalf("SetActiveResources proj-a: %v", err)
+	}
+	if err := rec.SetActiveResources(ctx, "proj-b", "dev", "dep-b", res); err != nil {
+		t.Fatalf("SetActiveResources proj-b: %v", err)
+	}
+
+	// Replacing proj-a/prod should not touch proj-a/dev or proj-b/dev.
+	if err := rec.SetActiveResources(ctx, "proj-a", "prod", "dep-c", nil); err != nil {
+		t.Fatalf("SetActiveResources proj-a/prod: %v", err)
+	}
+
+	rows, err := rdr.ListActiveResources(ctx, "proj-a", "dev")
+	if err != nil {
+		t.Fatalf("ListActiveResources proj-a/dev: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("proj-a/dev: expected 1 row, got %d", len(rows))
+	}
+
+	rows, err = rdr.ListActiveResources(ctx, "proj-b", "dev")
+	if err != nil {
+		t.Fatalf("ListActiveResources proj-b/dev: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("proj-b/dev: expected 1 row, got %d", len(rows))
+	}
+
+	rows, err = rdr.ListActiveResources(ctx, "proj-a", "prod")
+	if err != nil {
+		t.Fatalf("ListActiveResources proj-a/prod: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("proj-a/prod: expected 0 rows, got %d", len(rows))
+	}
+}
+
+func TestClearActiveResources(t *testing.T) {
+	t.Parallel()
+	d, err := Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer d.Close()
+	rec := NewRecorder(d)
+	rdr := NewReader(d)
+	ctx := context.Background()
+
+	res := []deploy.ActiveResourceRecord{
+		{ResourceKey: "service|default|api", Type: "service", Class: "default", ID: "api", ModuleID: "mod-svc"},
+	}
+	if err := rec.SetActiveResources(ctx, "proj", "dev", "dep-1", res); err != nil {
+		t.Fatalf("SetActiveResources: %v", err)
+	}
+	if err := rec.SetActiveResources(ctx, "proj", "prod", "dep-2", res); err != nil {
+		t.Fatalf("SetActiveResources prod: %v", err)
+	}
+
+	if err := rec.ClearActiveResources(ctx, "proj", "dev"); err != nil {
+		t.Fatalf("ClearActiveResources: %v", err)
+	}
+
+	rows, err := rdr.ListActiveResources(ctx, "proj", "dev")
+	if err != nil {
+		t.Fatalf("ListActiveResources dev after clear: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows after clear, got %d", len(rows))
+	}
+
+	// prod must be untouched.
+	rows, err = rdr.ListActiveResources(ctx, "proj", "prod")
+	if err != nil {
+		t.Fatalf("ListActiveResources prod: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("prod: expected 1 row, got %d", len(rows))
 	}
 }

--- a/internal/store/db/reader.go
+++ b/internal/store/db/reader.go
@@ -47,6 +47,18 @@ type DeploymentDetail struct {
 	Resources    []ResourceRow `json:"resources" yaml:"resources"`
 }
 
+// ActiveResourceRow is a single row from the active_resources table.
+type ActiveResourceRow struct {
+	ResourceKey  string `json:"resource_key" yaml:"resource_key"`
+	Type         string `json:"type" yaml:"type"`
+	Class        string `json:"class" yaml:"class"`
+	ID           string `json:"id" yaml:"id"`
+	ModuleID     string `json:"module_id" yaml:"module_id"`
+	DeploymentID string `json:"deployment_id" yaml:"deployment_id"`
+	OutputsJSON  string `json:"outputs_json,omitempty" yaml:"outputs_json,omitempty"`
+	UpdatedAt    string `json:"updated_at" yaml:"updated_at"`
+}
+
 // Reader queries the deployment history stored in DB.
 type Reader struct {
 	db *DB
@@ -138,4 +150,36 @@ func (r *Reader) GetDeployment(ctx context.Context, id string) (*DeploymentDetai
 		d.Resources = []ResourceRow{}
 	}
 	return &d, nil
+}
+
+// ListActiveResources returns the active resources for (project, env),
+// ordered by resource_key.
+func (r *Reader) ListActiveResources(ctx context.Context, project, env string) ([]ActiveResourceRow, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT resource_key, type, class, id, module_id, deployment_id,
+		        COALESCE(outputs_json, ''), updated_at
+		 FROM active_resources
+		 WHERE project = ? AND env = ?
+		 ORDER BY resource_key`,
+		project, env)
+	if err != nil {
+		return nil, fmt.Errorf("db: list active resources: %w", err)
+	}
+	defer rows.Close()
+	var out []ActiveResourceRow
+	for rows.Next() {
+		var ar ActiveResourceRow
+		if err := rows.Scan(&ar.ResourceKey, &ar.Type, &ar.Class, &ar.ID,
+			&ar.ModuleID, &ar.DeploymentID, &ar.OutputsJSON, &ar.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("db: scan active resource row: %w", err)
+		}
+		out = append(out, ar)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: list active resources: %w", err)
+	}
+	if out == nil {
+		out = []ActiveResourceRow{}
+	}
+	return out, nil
 }

--- a/internal/store/db/recorder.go
+++ b/internal/store/db/recorder.go
@@ -97,3 +97,47 @@ func (r *SQLiteRecorder) FinishDeployment(ctx context.Context, deploymentID stri
 	}
 	return nil
 }
+
+// SetActiveResources atomically replaces the active resource set for
+// (project, env): it deletes all existing rows for that pair then inserts
+// the new slice. The whole operation runs inside a single transaction.
+func (r *SQLiteRecorder) SetActiveResources(ctx context.Context, project, env, deploymentID string, resources []deploy.ActiveResourceRecord) error {
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("db: set active resources: begin: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM active_resources WHERE project = ? AND env = ?`, project, env); err != nil {
+		tx.Rollback()
+		return fmt.Errorf("db: set active resources: delete: %w", err)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	for _, res := range resources {
+		var outputs sql.NullString
+		if res.OutputsJSON != "" {
+			outputs = sql.NullString{String: res.OutputsJSON, Valid: true}
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO active_resources
+			 (project, env, resource_key, type, class, id, module_id, deployment_id, outputs_json, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			project, env, res.ResourceKey, res.Type, res.Class, res.ID,
+			res.ModuleID, deploymentID, outputs, now); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("db: set active resources: insert %s: %w", res.ResourceKey, err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("db: set active resources: commit: %w", err)
+	}
+	return nil
+}
+
+// ClearActiveResources removes all active resources for (project, env).
+func (r *SQLiteRecorder) ClearActiveResources(ctx context.Context, project, env string) error {
+	if _, err := r.db.ExecContext(ctx,
+		`DELETE FROM active_resources WHERE project = ? AND env = ?`, project, env); err != nil {
+		return fmt.Errorf("db: clear active resources: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
This PR adds functionality to track and query active resources for each (project, environment) pair. Active resources represent the live set of deployed resources and their outputs, persisted after successful deployments and cleared on destroy operations.

## Key Changes

- **Database Schema**: Added `active_resources` table with columns for project, env, resource_key, type, class, id, module_id, deployment_id, outputs_json, and updated_at. Primary key is (project, env, resource_key) to ensure one active resource per key per environment.

- **Recorder Interface**: Extended `Recorder` interface with two new methods:
  - `SetActiveResources()`: Atomically replaces the active resource set for a (project, env) pair in a single transaction
  - `ClearActiveResources()`: Removes all active resources for a (project, env) pair

- **Reader Interface**: Added `ListActiveResources()` method to query active resources for a (project, env) pair, ordered by resource_key

- **Deploy Integration**: 
  - After successful (non-dry-run, non-plan-only) deployments, persist the current active resource set with their outputs
  - On successful destroy operations, clear the active resources for that environment

- **CLI Command**: Added `get active-resources` subcommand to list active resources with support for table, JSON, and YAML output formats

- **Comprehensive Tests**: Added test coverage for:
  - Upsert and replace behavior of SetActiveResources
  - Isolation by project and environment
  - Clear operation
  - CLI output in multiple formats
  - Edge cases (empty table, wrong project, invalid output format)

## Implementation Details

- Active resources are stored with a timestamp (updated_at) indicating when they were last recorded
- The SetActiveResources operation is transactional: it deletes all existing rows for the (project, env) pair and inserts new ones atomically
- Resource outputs are stored as JSON strings for flexibility
- The implementation properly handles nullable outputs_json field

https://claude.ai/code/session_018H1ptMr3ZMrfAfCsKpmYe2