### PR TITLE
Deploy from deployment:// and environment:// sources (issue #34)

### DIFF
--- a/cmd/openporch/cmd_deploy.go
+++ b/cmd/openporch/cmd_deploy.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/krbrudeli/openporch/internal/config"
 	"github.com/krbrudeli/openporch/internal/deploy"
-	"github.com/krbrudeli/openporch/internal/manifest"
 	"github.com/krbrudeli/openporch/internal/store"
 	"github.com/krbrudeli/openporch/internal/store/db"
 )
@@ -30,7 +29,7 @@ func newDeployCmd() *cobra.Command {
 		planOnly    bool
 	)
 	cmd := &cobra.Command{
-		Use:   "deploy <manifest.yaml>",
+		Use:   "deploy <manifest.yaml | deployment://HEAD | deployment://<id> | environment://<env>>",
 		Short: "Deploy a manifest end-to-end",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,10 +39,33 @@ func newDeployCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			m, err := manifest.Load(args[0])
+
+			src, err := parseManifestSource(args[0])
 			if err != nil {
 				return err
 			}
+
+			// Open the SQLite store once if either history-source resolution
+			// or deployment recording needs it.
+			needDB := src.File == "" || !dryRun
+			var d *db.DB
+			if needDB {
+				d, err = db.Open(stateRoot)
+				if err != nil {
+					return err
+				}
+				defer d.Close()
+			}
+
+			var rdr *db.Reader
+			if d != nil {
+				rdr = db.NewReader(d)
+			}
+			m, err := resolveManifestSource(ctx, rdr, src, project, env)
+			if err != nil {
+				return err
+			}
+
 			if project == "" {
 				project = m.Metadata.Project
 			}
@@ -67,11 +89,6 @@ func newDeployCmd() *cobra.Command {
 				PlanOnly: planOnly,
 			}
 			if !dryRun {
-				d, err := db.Open(stateRoot)
-				if err != nil {
-					return err
-				}
-				defer d.Close()
 				opts.Recorder = db.NewRecorder(d)
 			}
 
@@ -80,59 +97,60 @@ func newDeployCmd() *cobra.Command {
 				return err
 			}
 
+			out := cmd.OutOrStdout()
 			if planOnly {
-				fmt.Printf("\nPlan-only deployment %s complete (status=planned).\n", res.DeploymentID)
-				fmt.Println("Run `opo get deployment` to review captured plans.")
+				fmt.Fprintf(out, "\nPlan-only deployment %s complete (status=planned).\n", res.DeploymentID)
+				fmt.Fprintln(out, "Run `opo get deployment` to review captured plans.")
 				return nil
 			}
 
 			if dryRun {
-				fmt.Printf("Dry-run complete. %d resource(s) would be deployed:\n\n", len(res.DryRunResources))
+				fmt.Fprintf(out, "Dry-run complete. %d resource(s) would be deployed:\n\n", len(res.DryRunResources))
 				for _, r := range res.DryRunResources {
-					fmt.Printf("  %-40s  module=%-30s  type=%s", r.Key, r.ModuleID, r.Type)
+					fmt.Fprintf(out, "  %-40s  module=%-30s  type=%s", r.Key, r.ModuleID, r.Type)
 					if r.Class != "" {
-						fmt.Printf("  class=%s", r.Class)
+						fmt.Fprintf(out, "  class=%s", r.Class)
 					}
 					if len(r.Providers) > 0 {
-						fmt.Printf("  providers=%s", strings.Join(r.Providers, ","))
+						fmt.Fprintf(out, "  providers=%s", strings.Join(r.Providers, ","))
 					}
-					fmt.Println()
+					fmt.Fprintln(out)
 				}
 				if renderDir != "" {
-					fmt.Printf("\nRendered HCL written to: %s\n", renderDir)
+					fmt.Fprintf(out, "\nRendered HCL written to: %s\n", renderDir)
 				}
 				return nil
 			}
 
-			fmt.Printf("\nDeployment %s succeeded.\n\n", res.DeploymentID)
+			fmt.Fprintf(out, "\nDeployment %s succeeded.\n\n", res.DeploymentID)
 			if len(res.Resolved) > 0 {
-				fmt.Println("Resource outputs:")
+				fmt.Fprintln(out, "Resource outputs:")
 				keys := make([]string, 0, len(res.Resolved))
 				for k := range res.Resolved {
 					keys = append(keys, k)
 				}
 				sort.Strings(keys)
 				for _, k := range keys {
-					fmt.Printf("  %s\n", k)
+					fmt.Fprintf(out, "  %s\n", k)
 					oks := make([]string, 0, len(res.Resolved[k]))
 					for ok := range res.Resolved[k] {
 						oks = append(oks, ok)
 					}
 					sort.Strings(oks)
 					for _, ok := range oks {
-						fmt.Printf("    %s = %v\n", ok, res.Resolved[k][ok])
+						fmt.Fprintf(out, "    %s = %v\n", ok, res.Resolved[k][ok])
 					}
 				}
 			}
 			if len(res.Outputs) > 0 {
-				fmt.Println("\nManifest outputs:")
+				fmt.Fprintln(out, "\nManifest outputs:")
 				keys := make([]string, 0, len(res.Outputs))
 				for k := range res.Outputs {
 					keys = append(keys, k)
 				}
 				sort.Strings(keys)
 				for _, k := range keys {
-					fmt.Printf("  %s = %s\n", k, res.Outputs[k])
+					fmt.Fprintf(out, "  %s = %s\n", k, res.Outputs[k])
 				}
 			}
 			return nil

--- a/cmd/openporch/cmd_deploy_integration_test.go
+++ b/cmd/openporch/cmd_deploy_integration_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+	"github.com/krbrudeli/openporch/internal/config"
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/integrationtest"
+	"github.com/krbrudeli/openporch/internal/manifest"
+	"github.com/krbrudeli/openporch/internal/runner"
+	"github.com/krbrudeli/openporch/internal/store"
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+// integrationPlatformYAML wires a single workload type to an inline OpenTofu
+// module that creates no real resources — just a string output. We can run a
+// full tofu init/apply cycle quickly without touching Docker.
+const integrationPlatformYAML = `
+apiVersion: openporch/v1alpha1
+kind: ResourceType
+id: workload
+output_schema:
+  type: object
+  properties:
+    name: {type: string}
+---
+apiVersion: openporch/v1alpha1
+kind: Module
+id: workload-noop
+resource_type: workload
+module_source: inline
+module_source_code: |
+  variable "name" { type = string, default = "noop" }
+  output "name" { value = var.name }
+---
+apiVersion: openporch/v1alpha1
+kind: ModuleRule
+id: catchall
+resource_type: workload
+module_id: workload-noop
+---
+apiVersion: openporch/v1alpha1
+kind: Runner
+id: local-tofu
+type: local-tofu
+---
+apiVersion: openporch/v1alpha1
+kind: RunnerRule
+id: catchall-runner
+runner_id: local-tofu
+`
+
+const integrationManifestYAML = `apiVersion: openporch/v1alpha1
+kind: Application
+metadata:
+  name: redeploy-app
+  project: redeploy-proj
+workloads:
+  api:
+    type: workload
+`
+
+// TestDeployRedeployFromHEAD covers issue #34: after an initial successful
+// deploy from a YAML file, re-deploying from "deployment://HEAD" must load
+// the manifest from SQLite history and produce an identical applied state.
+//
+// Run with: go test -tags=integration -timeout=5m ./cmd/openporch/...
+func TestDeployRedeployFromHEAD(t *testing.T) {
+	integrationtest.RequireTofu(t)
+
+	platformDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(platformDir, "platform.yaml"),
+		[]byte(integrationPlatformYAML), 0o644); err != nil {
+		t.Fatalf("write platform: %v", err)
+	}
+	manifestPath := filepath.Join(t.TempDir(), "manifest.yaml")
+	if err := os.WriteFile(manifestPath, []byte(integrationManifestYAML), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	cfg, err := config.Load(platformDir)
+	if err != nil {
+		t.Fatalf("load platform: %v", err)
+	}
+
+	stateRoot := t.TempDir()
+	openDB, err := db.Open(stateRoot)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { openDB.Close() })
+
+	const project = "redeploy-proj"
+	const env = "dev"
+	r := &runner.LocalTofu{PluginCacheDir: filepath.Join(stateRoot, "plugin-cache")}
+	s := &store.FS{Root: stateRoot}
+
+	doApply := func(ctx context.Context, m *v1.Manifest, deploymentID string) {
+		t.Helper()
+		opts := deploy.Options{
+			Manifest: m, Platform: cfg, Store: s, Runner: r, RunnerID: "local-tofu",
+			ProjectID: project, EnvID: env, EnvTypeID: "local",
+			Recorder:     db.NewRecorder(openDB),
+			DeploymentID: deploymentID,
+		}
+		if _, err := deploy.Run(ctx, opts); err != nil {
+			t.Fatalf("deploy.Run %s: %v", deploymentID, err)
+		}
+	}
+
+	// 1) Initial deploy from YAML file — should produce a recorded deployment.
+	mf, err := manifest.Load(manifestPath)
+	if err != nil {
+		t.Fatalf("manifest.Load: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	doApply(ctx, mf, "first")
+
+	// 2) Resolve `deployment://HEAD` against the recorded history; the
+	// resolver is the function under test for this issue.
+	src, err := parseManifestSource("deployment://HEAD")
+	if err != nil {
+		t.Fatalf("parseManifestSource: %v", err)
+	}
+	loaded, err := resolveManifestSource(ctx, db.NewReader(openDB), src, project, env)
+	if err != nil {
+		t.Fatalf("resolveManifestSource HEAD: %v", err)
+	}
+	if loaded.Metadata.Name != "redeploy-app" {
+		t.Fatalf("HEAD manifest Name = %q, want redeploy-app", loaded.Metadata.Name)
+	}
+	doApply(ctx, loaded, "from-head")
+
+	// 3) Both deployments should be present and succeeded; HEAD now points
+	// at "from-head".
+	rdr := db.NewReader(openDB)
+	det, err := rdr.GetLastSuccessfulDeployment(ctx, project, env)
+	if err != nil {
+		t.Fatalf("GetLastSuccessfulDeployment: %v", err)
+	}
+	if det == nil {
+		t.Fatal("no successful deployment found after redeploy")
+	}
+	if det.ID != "from-head" {
+		t.Errorf("HEAD deployment ID = %q, want from-head", det.ID)
+	}
+	if det.Status != "succeeded" {
+		t.Errorf("HEAD status = %q, want succeeded", det.Status)
+	}
+
+	rows, err := rdr.ListDeployments(ctx, project, env, 10)
+	if err != nil {
+		t.Fatalf("ListDeployments: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 deployments, got %d", len(rows))
+	}
+
+	// 4) Promote the same manifest into a new "prod" environment via
+	// environment://dev. This validates the cross-environment source path.
+	src, err = parseManifestSource("environment://dev")
+	if err != nil {
+		t.Fatalf("parseManifestSource: %v", err)
+	}
+	promoted, err := resolveManifestSource(ctx, rdr, src, project, "prod")
+	if err != nil {
+		t.Fatalf("resolveManifestSource environment://dev: %v", err)
+	}
+	if promoted.Metadata.Name != "redeploy-app" {
+		t.Errorf("promoted Name = %q, want redeploy-app", promoted.Metadata.Name)
+	}
+	// Apply to prod and confirm a new succeeded row appears for that env.
+	prodOpts := deploy.Options{
+		Manifest: promoted, Platform: cfg, Store: s, Runner: r, RunnerID: "local-tofu",
+		ProjectID: project, EnvID: "prod", EnvTypeID: "local",
+		Recorder: db.NewRecorder(openDB), DeploymentID: "prod-1",
+	}
+	if _, err := deploy.Run(ctx, prodOpts); err != nil {
+		t.Fatalf("deploy.Run prod: %v", err)
+	}
+	prodHEAD, err := rdr.GetLastSuccessfulDeployment(ctx, project, "prod")
+	if err != nil {
+		t.Fatalf("prod HEAD: %v", err)
+	}
+	if prodHEAD == nil || prodHEAD.ID != "prod-1" {
+		t.Errorf("prod HEAD = %+v, want id=prod-1", prodHEAD)
+	}
+}

--- a/cmd/openporch/cmd_deploy_integration_test.go
+++ b/cmd/openporch/cmd_deploy_integration_test.go
@@ -37,8 +37,13 @@ id: workload-noop
 resource_type: workload
 module_source: inline
 module_source_code: |
-  variable "name" { type = string, default = "noop" }
-  output "name" { value = var.name }
+  variable "name" {
+    type    = string
+    default = "noop"
+  }
+  output "name" {
+    value = var.name
+  }
 ---
 apiVersion: openporch/v1alpha1
 kind: ModuleRule

--- a/cmd/openporch/cmd_deploy_test.go
+++ b/cmd/openporch/cmd_deploy_test.go
@@ -1,0 +1,262 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+// runDeploy executes "openporch deploy <args...> --platform <p> --state-root <s>
+// --dry-run" so the pipeline runs through render but skips OpenTofu.
+func runDeploy(t *testing.T, stateRoot, platform string, args ...string) (string, error) {
+	t.Helper()
+	root := &cobra.Command{Use: "openporch", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(newDeployCmd())
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	allArgs := append([]string{"deploy"}, args...)
+	allArgs = append(allArgs, "--state-root", stateRoot, "--platform", platform, "--dry-run")
+	root.SetArgs(allArgs)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// writeDeployPlatform creates a minimum platform on disk wiring one inline
+// "workload" module via a catch-all rule.
+func writeDeployPlatform(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	platform := `
+apiVersion: openporch/v1alpha1
+kind: ResourceType
+id: workload
+---
+apiVersion: openporch/v1alpha1
+kind: Module
+id: workload-stub
+resource_type: workload
+module_source: inline
+module_source_code: |
+  output "ok" { value = "ok" }
+---
+apiVersion: openporch/v1alpha1
+kind: ModuleRule
+id: catchall
+resource_type: workload
+module_id: workload-stub
+---
+apiVersion: openporch/v1alpha1
+kind: Runner
+id: local-tofu
+type: local-tofu
+---
+apiVersion: openporch/v1alpha1
+kind: RunnerRule
+id: catchall-runner
+runner_id: local-tofu
+`
+	if err := os.WriteFile(filepath.Join(dir, "platform.yaml"), []byte(platform), 0o644); err != nil {
+		t.Fatalf("write platform: %v", err)
+	}
+	return dir
+}
+
+const deployManifest = `apiVersion: openporch/v1alpha1
+kind: Application
+metadata:
+  name: test-app
+  project: myproj
+workloads:
+  api:
+    type: workload
+`
+
+// seedDeployForCmd writes one finished deployment for (project, env) into the
+// SQLite store and returns its ID and the manifest YAML used.
+func seedDeployForCmd(t *testing.T, stateRoot, project, env, id string, started time.Time) {
+	t.Helper()
+	d, err := db.Open(stateRoot)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+	rec := db.NewRecorder(d)
+	ctx := context.Background()
+	if err := rec.StartDeployment(ctx, deploy.DeploymentRecord{
+		ID: id, Project: project, Env: env, EnvType: "local", Mode: "deploy",
+		StartedAt: started, ManifestYAML: deployManifest, GraphJSON: `{}`,
+	}); err != nil {
+		t.Fatalf("StartDeployment: %v", err)
+	}
+	if err := rec.FinishDeployment(ctx, id, "succeeded", started.Add(time.Minute)); err != nil {
+		t.Fatalf("FinishDeployment: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// File source (regression: existing path still works)
+// ---------------------------------------------------------------------------
+
+func TestDeploy_FileSource(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	mfDir := t.TempDir()
+	mfPath := filepath.Join(mfDir, "manifest.yaml")
+	if err := os.WriteFile(mfPath, []byte(deployManifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	out, err := runDeploy(t, stateRoot, platform, mfPath)
+	if err != nil {
+		t.Fatalf("runDeploy: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Dry-run complete") {
+		t.Errorf("expected dry-run output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "module=workload-stub") {
+		t.Errorf("expected module-stub line, got:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deployment://HEAD
+// ---------------------------------------------------------------------------
+
+func TestDeploy_DeploymentHEAD(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	seedDeployForCmd(t, stateRoot, "myproj", "dev", "first", base)
+	seedDeployForCmd(t, stateRoot, "myproj", "dev", "head-target", base.Add(time.Hour))
+
+	out, err := runDeploy(t, stateRoot, platform, "deployment://HEAD",
+		"--project", "myproj", "--env", "dev")
+	if err != nil {
+		t.Fatalf("runDeploy: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Dry-run complete") {
+		t.Errorf("expected dry-run output, got:\n%s", out)
+	}
+}
+
+func TestDeploy_DeploymentHEAD_RequiresProjectAndEnv(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	// --env defaults to "default"; project is empty so HEAD must reject.
+	_, err := runDeploy(t, stateRoot, platform, "deployment://HEAD")
+	if err == nil {
+		t.Fatal("expected error when project unset, got nil")
+	}
+	if !strings.Contains(err.Error(), "deployment://HEAD requires --project and --env") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeploy_DeploymentHEAD_NoSuccessful(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	_, err := runDeploy(t, stateRoot, platform, "deployment://HEAD",
+		"--project", "myproj", "--env", "dev")
+	if err == nil {
+		t.Fatal("expected error when no deployments exist, got nil")
+	}
+	if !strings.Contains(err.Error(), `no successful deployment found for project="myproj" env="dev"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deployment://<id>
+// ---------------------------------------------------------------------------
+
+func TestDeploy_DeploymentByID(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	seedDeployForCmd(t, stateRoot, "myproj", "dev", "dep-target",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	// --env left at default; the loaded manifest sets project itself.
+	out, err := runDeploy(t, stateRoot, platform, "deployment://dep-target")
+	if err != nil {
+		t.Fatalf("runDeploy: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Dry-run complete") {
+		t.Errorf("expected dry-run output, got:\n%s", out)
+	}
+}
+
+func TestDeploy_DeploymentByID_NotFound(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	_, err := runDeploy(t, stateRoot, platform, "deployment://missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `deployment "missing" not found`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// environment://<env>
+// ---------------------------------------------------------------------------
+
+func TestDeploy_EnvironmentSource(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	seedDeployForCmd(t, stateRoot, "myproj", "staging", "stg-1", base)
+
+	out, err := runDeploy(t, stateRoot, platform, "environment://staging",
+		"--project", "myproj", "--env", "prod")
+	if err != nil {
+		t.Fatalf("runDeploy: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Dry-run complete") {
+		t.Errorf("expected dry-run output, got:\n%s", out)
+	}
+}
+
+func TestDeploy_EnvironmentSource_NoSuccessful(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	_, err := runDeploy(t, stateRoot, platform, "environment://staging",
+		"--project", "myproj", "--env", "prod")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `no successful deployment found for project="myproj" env="staging"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDeploy_UnknownScheme(t *testing.T) {
+	t.Parallel()
+	platform := writeDeployPlatform(t)
+	stateRoot := t.TempDir()
+	_, err := runDeploy(t, stateRoot, platform, "s3://bucket/manifest.yaml")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `unknown manifest source scheme "s3"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/openporch/manifest_source.go
+++ b/cmd/openporch/manifest_source.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
+	"github.com/krbrudeli/openporch/internal/manifest"
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+// manifestSource is the parsed form of the deploy command's positional
+// argument. Exactly one of File, Deployment, or Environment is set.
+type manifestSource struct {
+	// File is a filesystem path to a YAML manifest (no scheme).
+	File string
+	// Deployment is set when the source is `deployment://<HEAD|UUID>`.
+	// Head reports whether the special `HEAD` selector was used.
+	Deployment   string
+	DeploymentID string
+	Head         bool
+	// Environment is set when the source is `environment://<env-id>`.
+	Environment string
+}
+
+// parseManifestSource classifies the deploy positional argument. It does not
+// touch the database or filesystem.
+func parseManifestSource(arg string) (manifestSource, error) {
+	switch {
+	case strings.HasPrefix(arg, "deployment://"):
+		ref := strings.TrimPrefix(arg, "deployment://")
+		if ref == "" {
+			return manifestSource{}, fmt.Errorf("deployment source requires HEAD or a deployment id: %q", arg)
+		}
+		s := manifestSource{Deployment: ref}
+		if ref == "HEAD" {
+			s.Head = true
+		} else {
+			s.DeploymentID = ref
+		}
+		return s, nil
+	case strings.HasPrefix(arg, "environment://"):
+		ref := strings.TrimPrefix(arg, "environment://")
+		if ref == "" {
+			return manifestSource{}, fmt.Errorf("environment source requires an environment id: %q", arg)
+		}
+		return manifestSource{Environment: ref}, nil
+	case strings.Contains(arg, "://"):
+		scheme := arg[:strings.Index(arg, "://")]
+		return manifestSource{}, fmt.Errorf("unknown manifest source scheme %q (want deployment:// or environment://)", scheme)
+	default:
+		if arg == "" {
+			return manifestSource{}, fmt.Errorf("manifest source is required")
+		}
+		return manifestSource{File: arg}, nil
+	}
+}
+
+// resolveManifestSource turns a parsed source into a *v1.Manifest. For
+// non-file sources it queries the SQLite reader for the deployment whose
+// stored manifest_yaml should be replayed; project and env qualify the query
+// for HEAD and environment lookups (and are ignored for explicit IDs).
+func resolveManifestSource(ctx context.Context, rdr *db.Reader, src manifestSource, project, env string) (*v1.Manifest, error) {
+	switch {
+	case src.File != "":
+		return manifest.Load(src.File)
+	case src.Head:
+		if project == "" || env == "" {
+			return nil, fmt.Errorf("deployment://HEAD requires --project and --env")
+		}
+		det, err := rdr.GetLastSuccessfulDeployment(ctx, project, env)
+		if err != nil {
+			return nil, err
+		}
+		if det == nil {
+			return nil, fmt.Errorf("no successful deployment found for project=%q env=%q", project, env)
+		}
+		return parseStoredManifest(det.ManifestYAML, det.ID)
+	case src.DeploymentID != "":
+		det, err := rdr.GetDeployment(ctx, src.DeploymentID)
+		if err != nil {
+			return nil, err
+		}
+		if det == nil {
+			return nil, fmt.Errorf("deployment %q not found", src.DeploymentID)
+		}
+		return parseStoredManifest(det.ManifestYAML, det.ID)
+	case src.Environment != "":
+		if project == "" {
+			return nil, fmt.Errorf("environment://%s requires --project", src.Environment)
+		}
+		det, err := rdr.GetLastSuccessfulDeployment(ctx, project, src.Environment)
+		if err != nil {
+			return nil, err
+		}
+		if det == nil {
+			return nil, fmt.Errorf("no successful deployment found for project=%q env=%q", project, src.Environment)
+		}
+		return parseStoredManifest(det.ManifestYAML, det.ID)
+	default:
+		return nil, fmt.Errorf("manifest source is required")
+	}
+}
+
+func parseStoredManifest(yamlText, deploymentID string) (*v1.Manifest, error) {
+	if yamlText == "" {
+		return nil, fmt.Errorf("deployment %q has no stored manifest", deploymentID)
+	}
+	m, err := manifest.LoadBytes([]byte(yamlText))
+	if err != nil {
+		return nil, fmt.Errorf("deployment %q: %w", deploymentID, err)
+	}
+	return m, nil
+}

--- a/cmd/openporch/manifest_source_test.go
+++ b/cmd/openporch/manifest_source_test.go
@@ -1,0 +1,325 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+func TestParseManifestSource(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		arg     string
+		want    manifestSource
+		wantErr string
+	}{
+		{
+			name: "file path",
+			arg:  "manifest.yaml",
+			want: manifestSource{File: "manifest.yaml"},
+		},
+		{
+			name: "file path with directories",
+			arg:  "./examples/foo/manifest.yaml",
+			want: manifestSource{File: "./examples/foo/manifest.yaml"},
+		},
+		{
+			name: "deployment HEAD",
+			arg:  "deployment://HEAD",
+			want: manifestSource{Deployment: "HEAD", Head: true},
+		},
+		{
+			name: "deployment by id",
+			arg:  "deployment://dep-abc123",
+			want: manifestSource{Deployment: "dep-abc123", DeploymentID: "dep-abc123"},
+		},
+		{
+			name: "environment",
+			arg:  "environment://staging",
+			want: manifestSource{Environment: "staging"},
+		},
+		{
+			name:    "empty",
+			arg:     "",
+			wantErr: "manifest source is required",
+		},
+		{
+			name:    "deployment without ref",
+			arg:     "deployment://",
+			wantErr: "deployment source requires HEAD",
+		},
+		{
+			name:    "environment without ref",
+			arg:     "environment://",
+			wantErr: "environment source requires",
+		},
+		{
+			name:    "unknown scheme",
+			arg:     "s3://bucket/manifest.yaml",
+			wantErr: `unknown manifest source scheme "s3"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseManifestSource(tc.arg)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %v does not contain %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("parseManifestSource(%q) mismatch (-want +got):\n%s", tc.arg, diff)
+			}
+		})
+	}
+}
+
+// seedDeployment writes one deployment to the SQLite store and optionally
+// marks it succeeded.
+func seedDeployment(t *testing.T, rec *db.SQLiteRecorder, id, project, env string, started time.Time, manifestYAML, status string) {
+	t.Helper()
+	ctx := context.Background()
+	if err := rec.StartDeployment(ctx, deploy.DeploymentRecord{
+		ID: id, Project: project, Env: env, EnvType: "local",
+		Mode: "deploy", StartedAt: started,
+		ManifestYAML: manifestYAML, GraphJSON: `{}`,
+	}); err != nil {
+		t.Fatalf("StartDeployment %s: %v", id, err)
+	}
+	if status != "" && status != "running" {
+		if err := rec.FinishDeployment(ctx, id, status, started.Add(time.Minute)); err != nil {
+			t.Fatalf("FinishDeployment %s: %v", id, err)
+		}
+	}
+}
+
+const validManifest = `apiVersion: openporch/v1alpha1
+kind: Application
+metadata:
+  name: test-app
+  project: myproj
+workloads:
+  api:
+    resources:
+      web:
+        type: service
+`
+
+func TestResolveManifestSource_File(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest.yaml")
+	if err := os.WriteFile(path, []byte(validManifest), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	m, err := resolveManifestSource(context.Background(), nil,
+		manifestSource{File: path}, "", "")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if m.Metadata.Name != "test-app" {
+		t.Errorf("Name = %q, want test-app", m.Metadata.Name)
+	}
+}
+
+func TestResolveManifestSource_DeploymentHEAD(t *testing.T) {
+	t.Parallel()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	rec := db.NewRecorder(d)
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	// Two succeeded deployments and one running — HEAD should return the
+	// latest succeeded by started_at.
+	seedDeployment(t, rec, "old", "myproj", "dev", base, "old: 1\n"+validManifest, "succeeded")
+	seedDeployment(t, rec, "newest", "myproj", "dev", base.Add(2*time.Hour), validManifest, "succeeded")
+	seedDeployment(t, rec, "running", "myproj", "dev", base.Add(3*time.Hour), validManifest, "running")
+	// Different env should not match.
+	seedDeployment(t, rec, "prod-only", "myproj", "prod", base.Add(4*time.Hour), validManifest, "succeeded")
+
+	m, err := resolveManifestSource(context.Background(), db.NewReader(d),
+		manifestSource{Deployment: "HEAD", Head: true}, "myproj", "dev")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if m.Metadata.Name != "test-app" {
+		t.Errorf("Name = %q, want test-app", m.Metadata.Name)
+	}
+}
+
+func TestResolveManifestSource_DeploymentByID(t *testing.T) {
+	t.Parallel()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	rec := db.NewRecorder(d)
+
+	seedDeployment(t, rec, "dep-target", "p", "e",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), validManifest, "succeeded")
+
+	m, err := resolveManifestSource(context.Background(), db.NewReader(d),
+		manifestSource{Deployment: "dep-target", DeploymentID: "dep-target"}, "", "")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if m.Metadata.Name != "test-app" {
+		t.Errorf("Name = %q, want test-app", m.Metadata.Name)
+	}
+}
+
+func TestResolveManifestSource_Environment(t *testing.T) {
+	t.Parallel()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	rec := db.NewRecorder(d)
+
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	seedDeployment(t, rec, "stg-1", "myproj", "staging", base, validManifest, "succeeded")
+	seedDeployment(t, rec, "stg-2", "myproj", "staging", base.Add(time.Hour),
+		strings.Replace(validManifest, "test-app", "from-staging", 1), "succeeded")
+	// Wrong project should be ignored.
+	seedDeployment(t, rec, "other-stg", "other", "staging", base.Add(2*time.Hour), validManifest, "succeeded")
+
+	m, err := resolveManifestSource(context.Background(), db.NewReader(d),
+		manifestSource{Environment: "staging"}, "myproj", "prod")
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if m.Metadata.Name != "from-staging" {
+		t.Errorf("Name = %q, want from-staging (latest staging deployment)", m.Metadata.Name)
+	}
+}
+
+func TestResolveManifestSource_Errors(t *testing.T) {
+	t.Parallel()
+	d, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	rec := db.NewRecorder(d)
+	// One running (not succeeded) deployment to confirm HEAD ignores it.
+	seedDeployment(t, rec, "live", "p", "e",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), validManifest, "running")
+	// One succeeded deployment with empty manifest_yaml to test that branch.
+	if err := rec.StartDeployment(context.Background(), deploy.DeploymentRecord{
+		ID: "empty", Project: "q", Env: "e", EnvType: "local",
+		Mode: "deploy", StartedAt: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		ManifestYAML: "", GraphJSON: `{}`,
+	}); err != nil {
+		t.Fatalf("seed empty: %v", err)
+	}
+	if err := rec.FinishDeployment(context.Background(), "empty", "succeeded",
+		time.Date(2026, 2, 1, 0, 1, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("finish empty: %v", err)
+	}
+	// One succeeded with broken manifest yaml so parseStoredManifest fails.
+	if err := rec.StartDeployment(context.Background(), deploy.DeploymentRecord{
+		ID: "broken", Project: "r", Env: "e", EnvType: "local",
+		Mode: "deploy", StartedAt: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		ManifestYAML: "this is: not: valid: yaml:\n", GraphJSON: `{}`,
+	}); err != nil {
+		t.Fatalf("seed broken: %v", err)
+	}
+	if err := rec.FinishDeployment(context.Background(), "broken", "succeeded",
+		time.Date(2026, 3, 1, 0, 1, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("finish broken: %v", err)
+	}
+	rdr := db.NewReader(d)
+
+	tests := []struct {
+		name    string
+		src     manifestSource
+		project string
+		env     string
+		wantErr string
+	}{
+		{
+			name:    "HEAD without project",
+			src:     manifestSource{Head: true},
+			env:     "e",
+			wantErr: "deployment://HEAD requires --project and --env",
+		},
+		{
+			name:    "HEAD without env",
+			src:     manifestSource{Head: true},
+			project: "p",
+			wantErr: "deployment://HEAD requires --project and --env",
+		},
+		{
+			name:    "HEAD no successful deployment",
+			src:     manifestSource{Head: true},
+			project: "p",
+			env:     "e",
+			wantErr: `no successful deployment found for project="p" env="e"`,
+		},
+		{
+			name:    "deployment id not found",
+			src:     manifestSource{DeploymentID: "missing"},
+			wantErr: `deployment "missing" not found`,
+		},
+		{
+			name:    "environment without project",
+			src:     manifestSource{Environment: "staging"},
+			wantErr: "environment://staging requires --project",
+		},
+		{
+			name:    "environment no successful deployment",
+			src:     manifestSource{Environment: "ghost"},
+			project: "p",
+			wantErr: `no successful deployment found for project="p" env="ghost"`,
+		},
+		{
+			name:    "deployment with empty manifest",
+			src:     manifestSource{DeploymentID: "empty"},
+			wantErr: `deployment "empty" has no stored manifest`,
+		},
+		{
+			name:    "deployment with broken manifest",
+			src:     manifestSource{DeploymentID: "broken"},
+			wantErr: `deployment "broken"`,
+		},
+		{
+			name:    "no source set",
+			src:     manifestSource{},
+			wantErr: "manifest source is required",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := resolveManifestSource(context.Background(), rdr, tc.src, tc.project, tc.env)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %v does not contain %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/manifest/manifest.go
+++ b/internal/manifest/manifest.go
@@ -16,12 +16,23 @@ func Load(path string) (*v1.Manifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("manifest: read %s: %w", path, err)
 	}
+	m, err := LoadBytes(b)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: %s: %w", path, err)
+	}
+	return m, nil
+}
+
+// LoadBytes parses and validates a manifest from a byte slice. It is the
+// in-memory equivalent of Load for callers that already hold the YAML bytes
+// (e.g. after retrieving them from SQLite history).
+func LoadBytes(b []byte) (*v1.Manifest, error) {
 	var m v1.Manifest
 	if err := yaml.Unmarshal(b, &m); err != nil {
-		return nil, fmt.Errorf("manifest: parse %s: %w", path, err)
+		return nil, fmt.Errorf("parse: %w", err)
 	}
 	if err := Validate(&m); err != nil {
-		return nil, fmt.Errorf("manifest: validate %s: %w", path, err)
+		return nil, fmt.Errorf("validate: %w", err)
 	}
 	return &m, nil
 }

--- a/internal/store/db/reader.go
+++ b/internal/store/db/reader.go
@@ -152,6 +152,26 @@ func (r *Reader) GetDeployment(ctx context.Context, id string) (*DeploymentDetai
 	return &d, nil
 }
 
+// GetLastSuccessfulDeployment returns the most recent successful deployment
+// for (project, env), or nil if none exists. Both project and env are
+// required — there is no notion of a "latest deployment" across environments.
+func (r *Reader) GetLastSuccessfulDeployment(ctx context.Context, project, env string) (*DeploymentDetail, error) {
+	row := r.db.QueryRowContext(ctx,
+		`SELECT id FROM deployments
+		 WHERE project = ? AND env = ? AND status = 'succeeded'
+		 ORDER BY started_at DESC LIMIT 1`,
+		project, env)
+	var id string
+	err := row.Scan(&id)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("db: get last successful deployment: %w", err)
+	}
+	return r.GetDeployment(ctx, id)
+}
+
 // ListActiveResources returns the active resources for (project, env),
 // ordered by resource_key.
 func (r *Reader) ListActiveResources(ctx context.Context, project, env string) ([]ActiveResourceRow, error) {

--- a/internal/store/db/reader_test.go
+++ b/internal/store/db/reader_test.go
@@ -301,6 +301,122 @@ func TestGetDeployment_NoResources(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// GetLastSuccessfulDeployment
+// ---------------------------------------------------------------------------
+
+func TestGetLastSuccessfulDeployment_Empty(t *testing.T) {
+	_, _, rdr := openTestDB(t)
+	det, err := rdr.GetLastSuccessfulDeployment(context.Background(), "p", "e")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if det != nil {
+		t.Errorf("expected nil for empty store, got %+v", det)
+	}
+}
+
+func TestGetLastSuccessfulDeployment_PicksLatestSucceeded(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Older succeeded.
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "old", Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt: base, ManifestYAML: "old: 1\n", GraphJSON: `{}`,
+	}, true, nil)
+	// Newer succeeded — should win.
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "newer", Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(time.Hour), ManifestYAML: "newer: 1\n", GraphJSON: `{}`,
+	}, true, nil)
+	// Newest but still running — should be ignored.
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "running", Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(2 * time.Hour), ManifestYAML: "running: 1\n", GraphJSON: `{}`,
+	}, false, nil)
+
+	det, err := rdr.GetLastSuccessfulDeployment(context.Background(), "p", "e")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if det == nil {
+		t.Fatal("expected non-nil")
+	}
+	if det.ID != "newer" {
+		t.Errorf("ID = %q, want newer", det.ID)
+	}
+	if det.ManifestYAML != "newer: 1\n" {
+		t.Errorf("ManifestYAML = %q, want newer: 1", det.ManifestYAML)
+	}
+}
+
+func TestGetLastSuccessfulDeployment_FilteredByEnv(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "stg", Project: "p", Env: "staging", EnvType: "local", Mode: "deploy",
+		StartedAt: base, ManifestYAML: "stg\n", GraphJSON: `{}`,
+	}, true, nil)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "prd", Project: "p", Env: "prod", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(time.Hour), ManifestYAML: "prd\n", GraphJSON: `{}`,
+	}, true, nil)
+
+	det, err := rdr.GetLastSuccessfulDeployment(context.Background(), "p", "staging")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if det == nil || det.ID != "stg" {
+		t.Errorf("expected stg, got %+v", det)
+	}
+}
+
+func TestGetLastSuccessfulDeployment_FilteredByProject(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "alpha", Project: "alpha", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt: base, ManifestYAML: "a\n", GraphJSON: `{}`,
+	}, true, nil)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "beta", Project: "beta", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt: base.Add(time.Hour), ManifestYAML: "b\n", GraphJSON: `{}`,
+	}, true, nil)
+
+	det, err := rdr.GetLastSuccessfulDeployment(context.Background(), "alpha", "e")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if det == nil || det.ID != "alpha" {
+		t.Errorf("expected alpha, got %+v", det)
+	}
+}
+
+func TestGetLastSuccessfulDeployment_OnlyFailedDeployments(t *testing.T) {
+	_, rec, rdr := openTestDB(t)
+	ctx := context.Background()
+	if err := rec.StartDeployment(ctx, deploy.DeploymentRecord{
+		ID: "fail", Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ManifestYAML: "x\n", GraphJSON: `{}`,
+	}); err != nil {
+		t.Fatalf("StartDeployment: %v", err)
+	}
+	if err := rec.FinishDeployment(ctx, "fail", "failed",
+		time.Date(2026, 1, 1, 0, 1, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("FinishDeployment: %v", err)
+	}
+
+	det, err := rdr.GetLastSuccessfulDeployment(ctx, "p", "e")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if det != nil {
+		t.Errorf("expected nil when only failed deployments exist, got %+v", det)
+	}
+}
+
 func TestGetDeployment_FinishedAtEmpty(t *testing.T) {
 	_, rec, rdr := openTestDB(t)
 	mustSeed(t, rec, deploy.DeploymentRecord{

--- a/internal/store/db/recorder.go
+++ b/internal/store/db/recorder.go
@@ -30,7 +30,7 @@ func (r *SQLiteRecorder) StartDeployment(ctx context.Context, d deploy.Deploymen
 		`INSERT INTO deployments (id, project, env, env_type, status, started_at, finished_at, mode)
 		 VALUES (?, ?, ?, ?, ?, ?, NULL, ?)`,
 		d.ID, d.Project, d.Env, d.EnvType, "running",
-		d.StartedAt.UTC().Format(time.RFC3339), d.Mode); err != nil {
+		d.StartedAt.UTC().Format(time.RFC3339Nano), d.Mode); err != nil {
 		tx.Rollback()
 		return fmt.Errorf("db: insert deployment: %w", err)
 	}
@@ -92,7 +92,7 @@ func (r *SQLiteRecorder) RecordResource(ctx context.Context, deploymentID string
 func (r *SQLiteRecorder) FinishDeployment(ctx context.Context, deploymentID string, status string, finishedAt time.Time) error {
 	if _, err := r.db.ExecContext(ctx,
 		`UPDATE deployments SET status = ?, finished_at = ? WHERE id = ?`,
-		status, finishedAt.UTC().Format(time.RFC3339), deploymentID); err != nil {
+		status, finishedAt.UTC().Format(time.RFC3339Nano), deploymentID); err != nil {
 		return fmt.Errorf("db: finish deployment: %w", err)
 	}
 	return nil
@@ -111,7 +111,7 @@ func (r *SQLiteRecorder) SetActiveResources(ctx context.Context, project, env, d
 		tx.Rollback()
 		return fmt.Errorf("db: set active resources: delete: %w", err)
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339Nano)
 	for _, res := range resources {
 		var outputs sql.NullString
 		if res.OutputsJSON != "" {


### PR DESCRIPTION
Accept three new manifest source schemes on `opo deploy`:

  deployment://HEAD     re-deploy the latest succeeded run for (project, env)
  deployment://<id>     re-deploy a specific historical record
  environment://<env>   promote an env's last manifest into another env

The argument is parsed up front; non-file sources query the SQLite store via
a new Reader.GetLastSuccessfulDeployment helper plus the existing
GetDeployment, then re-parse the stored manifest_yaml through a new
manifest.LoadBytes. Clear errors are returned when no matching deployment
exists or required flags (--project / --env for HEAD, --project for
environment) are missing.

Tests:
- Unit: parseManifestSource and resolveManifestSource cover every source
  type plus error paths (missing flags, missing deployment, broken/empty
  stored YAML, unknown scheme).
- Reader: GetLastSuccessfulDeployment ordering, env/project filtering, and
  failed-only no-match cases.
- CLI: dry-run exercises each source through the cobra command. The deploy
  command's user-facing prints were switched from fmt.Printf to
  cmd.OutOrStdout() so the test can capture them without mutating os.Stdout.
- Integration (build tag `integration`, requires tofu): full apply round-trip
  that deploys from a YAML file, re-deploys via deployment://HEAD, and
  promotes via environment://dev to a fresh env.