### PR TITLE
Add --resource filter to opo get tf and RenderGraph unit tests (issue #37)

### DIFF
--- a/cmd/openporch/cmd_get.go
+++ b/cmd/openporch/cmd_get.go
@@ -137,6 +137,7 @@ func newGetTFCmd() *cobra.Command {
 		platformDir string
 		outDir      string
 		stateRoot   string
+		resource    string
 	)
 	cmd := &cobra.Command{
 		Use:   "tf <deployment-id>",
@@ -179,6 +180,19 @@ func newGetTFCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			if resource != "" {
+				var filtered []deploy.RenderedResource
+				for _, r := range rendered {
+					if r.Key == resource {
+						filtered = append(filtered, r)
+						break
+					}
+				}
+				if len(filtered) == 0 {
+					return fmt.Errorf("resource %q not found in deployment %q", resource, deploymentID)
+				}
+				rendered = filtered
+			}
 			if outDir != "" {
 				return writeRenderedTF(outDir, rendered)
 			}
@@ -193,6 +207,8 @@ func newGetTFCmd() *cobra.Command {
 		"write rendered files under this directory instead of stdout")
 	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
 		"directory under which openporch metadata lives")
+	cmd.Flags().StringVar(&resource, "resource", "",
+		"show TF for a single resource only (by resource key, e.g. database|default|mydb)")
 	return cmd
 }
 

--- a/cmd/openporch/cmd_get_test.go
+++ b/cmd/openporch/cmd_get_test.go
@@ -4,18 +4,43 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
 	"github.com/krbrudeli/openporch/internal/deploy"
 	"github.com/krbrudeli/openporch/internal/store/db"
 )
+
+var update = flag.Bool("update", false, "update golden files")
+
+// goldenCLITest compares got against testdata/<name>.golden.txt, rewriting on -update.
+func goldenCLITest(t *testing.T, got, name string) {
+	t.Helper()
+	path := filepath.Join("testdata", name+".golden.txt")
+	if *update {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(path, []byte(got), 0o644); err != nil {
+			t.Fatalf("write golden %s: %v", path, err)
+		}
+	}
+	want, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read golden %s (run with -update to create): %v", path, err)
+	}
+	if diff := cmp.Diff(string(want), got); diff != "" {
+		t.Errorf("CLI output mismatch (-want +got):\n%s", diff)
+	}
+}
 
 // runGet executes "openporch get <args...> --state-root <stateRoot>" and
 // returns captured stdout plus any error.
@@ -517,6 +542,38 @@ func TestGetTF_NotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `deployment "no-such-id" not found`) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGetTF_ResourceFilter(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	platform := mustWriteTFPlatform(t)
+	depID := mustSeedTFDeployment(t, root)
+
+	// Request only the inline database resource (no absolute path in output).
+	out, err := runGet(t, root, "tf", depID, "--platform", platform,
+		"--resource", "database|default|shared.db")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	goldenCLITest(t, out, "get_tf_resource_filter")
+}
+
+func TestGetTF_ResourceFilter_NotFound(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	platform := mustWriteTFPlatform(t)
+	depID := mustSeedTFDeployment(t, root)
+
+	_, err := runGet(t, root, "tf", depID, "--platform", platform,
+		"--resource", "nonexistent|default|missing")
+	if err == nil {
+		t.Fatal("expected error for unknown resource key, got nil")
+	}
+	wantErr := `resource "nonexistent|default|missing" not found in deployment "dep-tf123"`
+	if diff := cmp.Diff(wantErr, err.Error()); diff != "" {
+		t.Errorf("error message mismatch (-want +got):\n%s", diff)
 	}
 }
 

--- a/cmd/openporch/testdata/get_tf_resource_filter.golden.txt
+++ b/cmd/openporch/testdata/get_tf_resource_filter.golden.txt
@@ -1,0 +1,14 @@
+===== database|default|shared.db/main.tf =====
+terraform {
+  required_providers {
+  }
+}
+
+module "main" {
+  source = "./module"
+}
+
+output "url" {
+  value = module.main.url
+}
+

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/krbrudeli/openporch/internal/graph"
+
 	"github.com/google/go-cmp/cmp"
 	v1 "github.com/krbrudeli/openporch/api/v1alpha1"
 	"github.com/krbrudeli/openporch/internal/runner/runnertest"
@@ -526,5 +528,100 @@ func TestRun_RecorderSideEffects(t *testing.T) {
 	}
 	if diff := cmp.Diff(want, events); diff != "" {
 		t.Errorf("recorder event sequence mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// TestRenderGraph_Basic verifies that RenderGraph returns one RenderedResource
+// per node, in topological order, with the correct resource keys.
+func TestRenderGraph_Basic(t *testing.T) {
+	t.Parallel()
+	plat := twoTypePlatform(t)
+
+	g := graph.New()
+	dbNode := &graph.Node{
+		Key: "database|default|shared.db", Type: "database", Class: "default",
+		ID: "shared.db", ModuleID: "database-stub",
+		Aliases: []string{"shared.db"}, Params: map[string]any{},
+	}
+	wlNode := &graph.Node{
+		Key: "workload|default|api", Type: "workload", Class: "default",
+		ID: "api", ModuleID: "workload-stub",
+		Aliases: []string{"workloads.api"}, Edges: []string{"database|default|shared.db"},
+		Params: map[string]any{},
+	}
+	if err := g.AddOrMerge(dbNode); err != nil {
+		t.Fatalf("AddOrMerge db: %v", err)
+	}
+	if err := g.AddOrMerge(wlNode); err != nil {
+		t.Fatalf("AddOrMerge workload: %v", err)
+	}
+
+	got, err := RenderGraph(RenderOptions{
+		Platform: plat, Graph: g,
+		ProjectID: "proj", EnvID: "env", EnvTypeID: "local",
+	})
+	if err != nil {
+		t.Fatalf("RenderGraph: %v", err)
+	}
+
+	wantKeys := []string{"database|default|shared.db", "workload|default|api"}
+	gotKeys := make([]string, len(got))
+	for i, r := range got {
+		gotKeys[i] = r.Key
+	}
+	if diff := cmp.Diff(wantKeys, gotKeys); diff != "" {
+		t.Errorf("rendered keys (-want +got):\n%s", diff)
+	}
+	for _, r := range got {
+		if r.HCL == "" {
+			t.Errorf("resource %q: rendered HCL is empty", r.Key)
+		}
+	}
+}
+
+// TestRenderGraph_SingleNode verifies that RenderGraph works for a graph with
+// a single node.
+func TestRenderGraph_SingleNode(t *testing.T) {
+	t.Parallel()
+	plat := minimalPlatform(t)
+
+	g := graph.New()
+	if err := g.AddOrMerge(&graph.Node{
+		Key: "workload|default|api", Type: "workload", Class: "default",
+		ID: "api", ModuleID: "workload-stub", Params: map[string]any{},
+	}); err != nil {
+		t.Fatalf("AddOrMerge: %v", err)
+	}
+
+	got, err := RenderGraph(RenderOptions{
+		Platform: plat, Graph: g,
+		ProjectID: "proj", EnvID: "env", EnvTypeID: "local",
+	})
+	if err != nil {
+		t.Fatalf("RenderGraph: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("RenderGraph returned %d resources, want 1", len(got))
+	}
+	if diff := cmp.Diff("workload|default|api", got[0].Key); diff != "" {
+		t.Errorf("resource key (-want +got):\n%s", diff)
+	}
+	if got[0].HCL == "" {
+		t.Error("rendered HCL is empty")
+	}
+}
+
+// TestRenderGraph_NilInputs verifies that RenderGraph returns errors for
+// missing required inputs.
+func TestRenderGraph_NilInputs(t *testing.T) {
+	t.Parallel()
+	plat := minimalPlatform(t)
+	g := graph.New()
+
+	if _, err := RenderGraph(RenderOptions{Platform: nil, Graph: g}); err == nil {
+		t.Error("expected error for nil platform, got nil")
+	}
+	if _, err := RenderGraph(RenderOptions{Platform: plat, Graph: nil}); err == nil {
+		t.Error("expected error for nil graph, got nil")
 	}
 }


### PR DESCRIPTION
- newGetTFCmd: add --resource <key> flag that filters rendered output to
  a single resource; returns a clear error when the key is not in the
  saved deployment graph
- deploy_test: add TestRenderGraph_Basic, TestRenderGraph_SingleNode, and
  TestRenderGraph_NilInputs covering the re-rendering logic directly
- cmd_get_test: add TestGetTF_ResourceFilter (golden file) and
  TestGetTF_ResourceFilter_NotFound to cover the new flag end-to-end

https://claude.ai/code/session_01PLifYqU78NsGGa2CoquBaA