### PR TITLE
Support ${self.outputs.*} placeholders in coprovisioned resources

### DIFF
--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -433,6 +433,7 @@ func renderNodeHCL(
 		OrgID: orgID, ProjectID: projectID, EnvID: envID,
 		EnvTypeID: envTypeID, ResType: n.Type, ResClass: n.Class, ResID: n.ID,
 		WorkloadName: workloadFromAliases(n.Aliases),
+		SelfAlias:    n.SelfAlias,
 	}
 
 	// Merge module_inputs (static) with manifest params (dev-supplied).

--- a/internal/deploy/deploy_record.go
+++ b/internal/deploy/deploy_record.go
@@ -17,14 +17,15 @@ type graphSnapshot struct {
 }
 
 type nodeSnapshot struct {
-	Key      string         `json:"key"`
-	Type     string         `json:"type"`
-	Class    string         `json:"class"`
-	ID       string         `json:"id"`
-	ModuleID string         `json:"module_id,omitempty"`
-	Aliases  []string       `json:"aliases,omitempty"`
-	Edges    []string       `json:"edges,omitempty"`
-	Params   map[string]any `json:"params,omitempty"`
+	Key       string         `json:"key"`
+	Type      string         `json:"type"`
+	Class     string         `json:"class"`
+	ID        string         `json:"id"`
+	ModuleID  string         `json:"module_id,omitempty"`
+	Aliases   []string       `json:"aliases,omitempty"`
+	SelfAlias string         `json:"self_alias,omitempty"`
+	Edges     []string       `json:"edges,omitempty"`
+	Params    map[string]any `json:"params,omitempty"`
 }
 
 // serializeGraph returns the JSON text of the graph snapshot. Errors are
@@ -37,8 +38,8 @@ func serializeGraph(g *graph.Graph) (string, error) {
 	for _, n := range g.Nodes {
 		snap.Nodes = append(snap.Nodes, nodeSnapshot{
 			Key: n.Key, Type: n.Type, Class: n.Class, ID: n.ID,
-			ModuleID: n.ModuleID, Aliases: n.Aliases, Edges: n.Edges,
-			Params: n.Params,
+			ModuleID: n.ModuleID, Aliases: n.Aliases, SelfAlias: n.SelfAlias,
+			Edges: n.Edges, Params: n.Params,
 		})
 	}
 	b, err := json.Marshal(snap)
@@ -61,21 +62,35 @@ func GraphFromSnapshot(snapshot string) (*graph.Graph, error) {
 	g := graph.New()
 	for _, n := range snap.Nodes {
 		node := &graph.Node{
-			Key:      n.Key,
-			Type:     n.Type,
-			Class:    n.Class,
-			ID:       n.ID,
-			ModuleID: n.ModuleID,
-			Aliases:  n.Aliases,
-			Edges:    n.Edges,
-			Params:   n.Params,
-			Status:   "pending",
+			Key:       n.Key,
+			Type:      n.Type,
+			Class:     n.Class,
+			ID:        n.ID,
+			ModuleID:  n.ModuleID,
+			Aliases:   n.Aliases,
+			SelfAlias: n.SelfAlias,
+			Edges:     n.Edges,
+			Params:    n.Params,
+			Status:    "pending",
 		}
 		if node.Params == nil {
 			node.Params = map[string]any{}
 		}
 		if err := g.AddOrMerge(node); err != nil {
 			return nil, fmt.Errorf("deploy: graph snapshot node %q: %w", n.Key, err)
+		}
+	}
+	// Coprovisioned nodes whose parent has no manifest alias carry the
+	// parent's node key as their self-alias; make those resolvable again.
+	for _, n := range g.Nodes {
+		if n.SelfAlias == "" {
+			continue
+		}
+		if _, ok := g.AliasIndex[n.SelfAlias]; ok {
+			continue
+		}
+		if _, ok := g.Nodes[n.SelfAlias]; ok {
+			g.AliasIndex[n.SelfAlias] = n.SelfAlias
 		}
 	}
 	return g, nil

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -608,6 +609,50 @@ func TestRenderGraph_SingleNode(t *testing.T) {
 	}
 	if got[0].HCL == "" {
 		t.Error("rendered HCL is empty")
+	}
+}
+
+// TestRenderNodeHCL_SelfPlaceholderResolvesParentOutputs verifies that a
+// coprovisioned node's ${self.outputs.*} placeholder resolves to the parent
+// (current) resource's outputs during render.
+func TestRenderNodeHCL_SelfPlaceholderResolvesParentOutputs(t *testing.T) {
+	t.Parallel()
+	plat := &v1.PlatformConfig{
+		RootDir: t.TempDir(),
+		ResourceTypes: map[string]v1.ResourceType{
+			"postgres": {ID: "postgres"},
+			"monitor":  {ID: "monitor"},
+		},
+		Modules: map[string]v1.Module{
+			"postgres-stub": {ID: "postgres-stub", ResourceType: "postgres", ModuleSource: "inline", ModuleSourceCode: ``},
+			"monitor-stub":  {ID: "monitor-stub", ResourceType: "monitor", ModuleSource: "inline", ModuleSourceCode: ``},
+		},
+		Providers: map[string]v1.Provider{},
+		Runners:   map[string]v1.Runner{},
+	}
+	g := graph.New()
+	if err := g.AddOrMerge(&graph.Node{
+		Key: "postgres|default|db1", Type: "postgres", Class: "default", ID: "db1",
+		ModuleID: "postgres-stub", Aliases: []string{"workloads.api.db"},
+		Params: map[string]any{}, Outputs: map[string]any{"url": "postgres://db"},
+	}); err != nil {
+		t.Fatalf("AddOrMerge parent: %v", err)
+	}
+	if err := g.AddOrMerge(&graph.Node{
+		Key: "monitor|default|db1", Type: "monitor", Class: "default", ID: "db1",
+		ModuleID: "monitor-stub", SelfAlias: "workloads.api.db",
+		Params: map[string]any{"conn": "${self.outputs.url}"},
+		Edges:  []string{"postgres|default|db1"},
+	}); err != nil {
+		t.Fatalf("AddOrMerge monitor: %v", err)
+	}
+
+	hcl, _, _, err := renderNodeHCL(g, g.Nodes["monitor|default|db1"], plat, "proj", "env", "local", "", false)
+	if err != nil {
+		t.Fatalf("renderNodeHCL: %v", err)
+	}
+	if !strings.Contains(hcl, "postgres://db") {
+		t.Errorf("expected resolved self output in rendered HCL, got:\n%s", hcl)
 	}
 }
 

--- a/internal/expr/expr.go
+++ b/internal/expr/expr.go
@@ -1,8 +1,8 @@
 // Package expr resolves placeholder expressions of the form ${path.parts}.
 // v0 supports: ${context.*}, ${resources.<alias>.outputs.<key>},
 // ${shared.<alias>.outputs.<key>}, ${workloads.<name>.outputs.<key>},
-// ${var.NAME}. Unresolved references return ErrUnresolved so the deploy
-// pipeline can re-render in a later wave.
+// ${self.outputs.<key>}, ${var.NAME}. Unresolved references return
+// ErrUnresolved so the deploy pipeline can re-render in a later wave.
 package expr
 
 import (
@@ -27,6 +27,11 @@ type Context struct {
 	ResClass     string
 	ResID        string
 	WorkloadName string // local context: name of enclosing workload, if any
+
+	// SelfAlias names the current (parent) resource for ${self.outputs.*}.
+	// Only set when resolving params of a coprovisioned resource; empty
+	// elsewhere, in which case ${self.*} is a hard error.
+	SelfAlias string
 }
 
 // AsMap returns the context as a flat map keyed by the suffix after "context.".
@@ -155,6 +160,17 @@ func lookup(expr string, ctx Context, st State, vars Vars) (any, error) {
 			alias = parts[1] // best-effort fallback
 		}
 		return outputLookup(st, alias, parts[3:])
+	case "self":
+		// self.outputs.<key>... — the current (parent) resource's outputs.
+		// Valid only inside coprovisioned resource params, where SelfAlias
+		// is populated; anywhere else this is a configuration error.
+		if len(parts) < 3 || parts[1] != "outputs" {
+			return nil, fmt.Errorf("malformed self reference: %s", expr)
+		}
+		if ctx.SelfAlias == "" {
+			return nil, fmt.Errorf("${self.*} is only valid in coprovisioned resource params: %s", expr)
+		}
+		return outputLookup(st, ctx.SelfAlias, parts[2:])
 	case "shared":
 		if len(parts) < 4 || parts[2] != "outputs" {
 			return nil, fmt.Errorf("malformed shared reference: %s", expr)

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -52,6 +53,47 @@ func TestResolve_unresolvedLeavesPlaceholder(t *testing.T) {
 		t.Fatalf("want ErrUnresolved, got %v", err)
 	}
 	if got != "DB=${resources.db.outputs.url}" {
+		t.Errorf("expected placeholder retained, got %q", got)
+	}
+}
+
+func TestResolve_self(t *testing.T) {
+	t.Parallel()
+	st := fakeState{
+		"workloads.api.db": {"url": "postgres://db", "creds": map[string]any{"user": "app"}},
+	}
+	got, err := Resolve(
+		"DB=${self.outputs.url} USER=${self.outputs.creds.user}",
+		Context{SelfAlias: "workloads.api.db"}, st, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "DB=postgres://db USER=app" {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestResolve_selfOutsideCoprovisionedIsError(t *testing.T) {
+	t.Parallel()
+	_, err := Resolve("X=${self.outputs.url}", Context{}, fakeState{}, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if errors.Is(err, ErrUnresolved) {
+		t.Fatalf("want a hard error, got ErrUnresolved: %v", err)
+	}
+	if !strings.Contains(err.Error(), "coprovisioned") {
+		t.Errorf("error should mention coprovisioned context, got %q", err)
+	}
+}
+
+func TestResolve_selfUnresolvedLeavesPlaceholder(t *testing.T) {
+	t.Parallel()
+	got, err := Resolve("X=${self.outputs.url}", Context{SelfAlias: "workloads.api.db"}, fakeState{}, nil)
+	if !errors.Is(err, ErrUnresolved) {
+		t.Fatalf("want ErrUnresolved, got %v", err)
+	}
+	if got != "X=${self.outputs.url}" {
 		t.Errorf("expected placeholder retained, got %q", got)
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -27,6 +27,11 @@ type Node struct {
 	// e.g. for a workload-scoped resource: workloads.<workload>.<alias>
 	Aliases []string
 
+	// SelfAlias is set when this node was produced by coprovisioning and its
+	// params reference ${self.*}; it names the parent resource (an entry in
+	// Graph.AliasIndex) whose outputs back the self placeholder.
+	SelfAlias string
+
 	// Edges names other nodes (by Key) that must apply before this one.
 	Edges []string
 
@@ -84,6 +89,10 @@ func (g *Graph) AddOrMerge(n *Node) error {
 			if !contains(existing.Edges, e) {
 				existing.Edges = append(existing.Edges, e)
 			}
+		}
+		// Adopt a self-alias if we don't already have one.
+		if existing.SelfAlias == "" && n.SelfAlias != "" {
+			existing.SelfAlias = n.SelfAlias
 		}
 		// Merge params (no conflict tolerated except identical).
 		for k, v := range n.Params {
@@ -298,13 +307,21 @@ func expandDeps(g *Graph, parent *Node, mod v1.Module) error {
 		}
 		id := resolveID(parent.ID, cp.ID)
 		key := NodeKey(cp.Type, class, id)
-		if err := g.AddOrMerge(&Node{
+		// Referencing ${self.*} in the coprovisioned params makes the
+		// coprovisioned resource depend on the current one, regardless of
+		// the is_dependent_on_current flag (per spec).
+		usesSelf := referencesSelf(cp.Params)
+		node := &Node{
 			Key: key, Type: cp.Type, Class: class, ID: id,
 			Params: cp.Params, Status: "pending",
-		}); err != nil {
+		}
+		if usesSelf {
+			node.SelfAlias = selfAliasFor(g, parent)
+		}
+		if err := g.AddOrMerge(node); err != nil {
 			return err
 		}
-		if cp.IsDependentOnCurrent {
+		if cp.IsDependentOnCurrent || usesSelf {
 			// Coprovisioned applies AFTER parent.
 			g.Nodes[key].Edges = appendUnique(g.Nodes[key].Edges, parent.Key)
 		} else {
@@ -313,6 +330,39 @@ func expandDeps(g *Graph, parent *Node, mod v1.Module) error {
 		}
 	}
 	return nil
+}
+
+// selfAliasFor returns an alias that resolves to parent via Graph.AliasIndex.
+// Workload/shared resources already carry a manifest alias; resources produced
+// by expansion don't, so we register their canonical key as a self-alias.
+func selfAliasFor(g *Graph, parent *Node) string {
+	if len(parent.Aliases) > 0 {
+		return parent.Aliases[0]
+	}
+	g.AliasIndex[parent.Key] = parent.Key
+	return parent.Key
+}
+
+// referencesSelf reports whether any string nested in v contains a ${self.*}
+// placeholder.
+func referencesSelf(v any) bool {
+	switch x := v.(type) {
+	case string:
+		return strings.Contains(x, "${self.")
+	case map[string]any:
+		for _, vv := range x {
+			if referencesSelf(vv) {
+				return true
+			}
+		}
+	case []any:
+		for _, vv := range x {
+			if referencesSelf(vv) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ModuleResolver picks a module for a node. Implemented by the deploy

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -208,6 +208,69 @@ func TestBuild_moduleDependenciesExpanded(t *testing.T) {
 	}
 }
 
+func TestBuild_coprovisionedSelfPlaceholderForcesDependency(t *testing.T) {
+	t.Parallel()
+	mod := v1.Module{
+		ID: "postgres-docker", ResourceType: "postgres",
+		Coprovisioned: []v1.Coprovisioned{
+			// is_dependent_on_current is false here; the ${self.*} reference
+			// must still flip the edge so the monitor applies AFTER the db.
+			{Type: "monitor", Params: map[string]any{"conn": "${self.outputs.url}"}},
+		},
+	}
+	m := &v1.Manifest{
+		Workloads: map[string]v1.Workload{
+			"a": {Resources: map[string]v1.ResourceRef{"db": {Type: "postgres", ID: "db1"}}},
+		},
+	}
+	g, err := Build(m, map[string]v1.Module{"postgres-docker": mod}, fakeResolver{"postgres-docker", "postgres"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	workloadKey := NodeKey("workload", v1.DefaultClass, "a")
+	dbKey := NodeKey("postgres", v1.DefaultClass, "db1")
+	monitorKey := NodeKey("monitor", v1.DefaultClass, "db1")
+	want := &Graph{
+		Nodes: map[string]*Node{
+			workloadKey: {
+				Key:     workloadKey,
+				Type:    "workload",
+				Class:   v1.DefaultClass,
+				ID:      "a",
+				Aliases: []string{"workloads.a"},
+				Edges:   []string{dbKey},
+				Status:  "pending",
+			},
+			dbKey: {
+				Key:      dbKey,
+				Type:     "postgres",
+				Class:    v1.DefaultClass,
+				ID:       "db1",
+				Aliases:  []string{"workloads.a.db"},
+				ModuleID: "postgres-docker",
+				Status:   "pending",
+			},
+			monitorKey: {
+				Key:       monitorKey,
+				Type:      "monitor",
+				Class:     v1.DefaultClass,
+				ID:        "db1",
+				Params:    map[string]any{"conn": "${self.outputs.url}"},
+				SelfAlias: "workloads.a.db",
+				Edges:     []string{dbKey},
+				Status:    "pending",
+			},
+		},
+		AliasIndex: map[string]string{
+			"workloads.a":    workloadKey,
+			"workloads.a.db": dbKey,
+		},
+	}
+	if diff := graphDiff(want, g); diff != "" {
+		t.Errorf("Build() mismatch (-want +got):\n%s", diff)
+	}
+}
+
 func TestTopoSort_dependenciesBeforeDependents(t *testing.T) {
 	t.Parallel()
 	g := New()


### PR DESCRIPTION
## Summary

Add support for `${self.outputs.*}` placeholders in coprovisioned resource parameters, allowing them to reference the parent resource's outputs. When a coprovisioned resource uses `${self.*}` in its params, it automatically becomes dependent on the parent resource, regardless of the `is_dependent_on_current` flag.

## Key Changes

- **graph/graph.go**: 
  - Added `SelfAlias` field to `Node` to track the parent resource for coprovisioned nodes
  - Updated `expandDeps()` to detect `${self.*}` references via new `referencesSelf()` helper
  - Added `selfAliasFor()` to resolve parent aliases for self-references
  - Modified dependency logic to force parent→child edge when `${self.*}` is used
  - Updated `AddOrMerge()` to preserve `SelfAlias` during node merging

- **expr/expr.go**:
  - Added `SelfAlias` field to `Context` struct
  - Implemented `${self.outputs.<key>}` resolution in `lookup()` function
  - Added validation to ensure `${self.*}` is only used in coprovisioned context (hard error otherwise)

- **deploy/deploy.go**:
  - Updated `renderNodeHCL()` to pass `SelfAlias` to expression resolution context

- **deploy/deploy_record.go**:
  - Added `SelfAlias` field to `nodeSnapshot` struct for serialization
  - Updated `serializeGraph()` and `GraphFromSnapshot()` to handle `SelfAlias` persistence
  - Added logic to restore `AliasIndex` entries for node-key-based self-aliases after deserialization

- **Tests**:
  - Added `TestBuild_coprovisionedSelfPlaceholderForcesDependency` to verify graph construction with self-references
  - Added `TestRenderNodeHCL_SelfPlaceholderResolvesParentOutputs` to verify output resolution during rendering
  - Added three `expr` package tests: `TestResolve_self`, `TestResolve_selfOutsideCoprovisionedIsError`, and `TestResolve_selfUnresolvedLeavesPlaceholder`

## Implementation Details

- Self-references are detected by scanning parameter values for the substring `"${self."` recursively through maps and slices
- When a coprovisioned node references `${self.*}`, its `SelfAlias` is set to either the parent's first manifest alias or the parent's node key (registered in `AliasIndex`)
- The dependency edge is created from parent to coprovisioned child, ensuring the parent applies first
- Unresolved self-references (when parent outputs aren't yet available) are treated like other unresolved placeholders and trigger re-rendering in a later wave
- Using `${self.*}` outside coprovisioned context is a hard error, not a deferred unresolved reference

https://claude.ai/code/session_01HtoVsqM3qGb2qNvCfCp9F8