### PR TITLE
Add opo rollback command pinned to past deployment modules (issue #43)

### DIFF
--- a/cmd/openporch/cmd_rollback.go
+++ b/cmd/openporch/cmd_rollback.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krbrudeli/openporch/internal/config"
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/manifest"
+	"github.com/krbrudeli/openporch/internal/store"
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+func newRollbackCmd() *cobra.Command {
+	var (
+		platformDir string
+		envType     string
+		stateRoot   string
+		tofuBinary  string
+		dryRun      bool
+		renderDir   string
+		planOnly    bool
+	)
+	cmd := &cobra.Command{
+		Use:   "rollback <project> <env> <deployment-id>",
+		Short: "Redeploy a past deployment with its original module IDs frozen",
+		Long: `rollback replays a past deployment's manifest with module IDs pinned to
+the modules that deployment resolved against, bypassing the current module
+rules. Provider and runner configuration always come from current platform
+state. The new deployment is recorded with mode=rollback.
+
+Use this when module rules have changed since a known-good deployment and
+"opo deploy deployment://<id>" would re-pick modules under the new rules.`,
+		Args: cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			project, env, deploymentID := args[0], args[1], args[2]
+			if project == "" || env == "" || deploymentID == "" {
+				return fmt.Errorf("project, env, and deployment-id are required")
+			}
+
+			if dryRun && planOnly {
+				return fmt.Errorf("--dry-run and --plan-only are mutually exclusive")
+			}
+
+			ctx := context.Background()
+			cfg, err := config.Load(platformDir)
+			if err != nil {
+				return err
+			}
+
+			d, err := db.Open(stateRoot)
+			if err != nil {
+				return err
+			}
+			defer d.Close()
+			rdr := db.NewReader(d)
+
+			det, err := rdr.GetDeployment(ctx, deploymentID)
+			if err != nil {
+				return err
+			}
+			if det == nil {
+				return fmt.Errorf("deployment %q not found", deploymentID)
+			}
+			if det.Project != project {
+				return fmt.Errorf("deployment %q belongs to project %q, not %q",
+					deploymentID, det.Project, project)
+			}
+			if det.Env != env {
+				return fmt.Errorf("deployment %q belongs to env %q, not %q",
+					deploymentID, det.Env, env)
+			}
+			if det.ManifestYAML == "" {
+				return fmt.Errorf("deployment %q has no stored manifest", deploymentID)
+			}
+
+			m, err := manifest.LoadBytes([]byte(det.ManifestYAML))
+			if err != nil {
+				return fmt.Errorf("deployment %q: %w", deploymentID, err)
+			}
+
+			overrides, err := rdr.GetDeploymentModuleAssignments(ctx, deploymentID)
+			if err != nil {
+				return err
+			}
+			if len(overrides) == 0 {
+				return fmt.Errorf("deployment %q has no recorded module assignments to roll back to", deploymentID)
+			}
+
+			runnerID, r, err := resolveRunner(cfg, project, env, envType, stateRoot, tofuBinary)
+			if err != nil {
+				return err
+			}
+
+			opts := deploy.Options{
+				Manifest: m, Platform: cfg, Store: &store.FS{Root: stateRoot},
+				Runner: r, RunnerID: runnerID,
+				ProjectID: project, EnvID: env, EnvTypeID: envType,
+				DryRun: dryRun, RenderDir: renderDir,
+				PlanOnly:        planOnly,
+				ModuleOverrides: overrides,
+				Mode:            "rollback",
+			}
+			if !dryRun {
+				opts.Recorder = db.NewRecorder(d)
+			}
+
+			res, err := deploy.Run(ctx, opts)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			if planOnly {
+				fmt.Fprintf(out, "\nRollback plan-only %s complete (status=planned).\n", res.DeploymentID)
+				fmt.Fprintln(out, "Run `opo get deployment` to review captured plans.")
+				return nil
+			}
+
+			if dryRun {
+				fmt.Fprintf(out, "Dry-run rollback from %s. %d resource(s) would be deployed:\n\n",
+					deploymentID, len(res.DryRunResources))
+				for _, r := range res.DryRunResources {
+					fmt.Fprintf(out, "  %-40s  module=%-30s  type=%s", r.Key, r.ModuleID, r.Type)
+					if r.Class != "" {
+						fmt.Fprintf(out, "  class=%s", r.Class)
+					}
+					if len(r.Providers) > 0 {
+						fmt.Fprintf(out, "  providers=%s", strings.Join(r.Providers, ","))
+					}
+					fmt.Fprintln(out)
+				}
+				if renderDir != "" {
+					fmt.Fprintf(out, "\nRendered HCL written to: %s\n", renderDir)
+				}
+				return nil
+			}
+
+			fmt.Fprintf(out, "\nRollback %s succeeded (from %s).\n\n", res.DeploymentID, deploymentID)
+			if len(res.Resolved) > 0 {
+				fmt.Fprintln(out, "Resource outputs:")
+				keys := make([]string, 0, len(res.Resolved))
+				for k := range res.Resolved {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					fmt.Fprintf(out, "  %s\n", k)
+					oks := make([]string, 0, len(res.Resolved[k]))
+					for ok := range res.Resolved[k] {
+						oks = append(oks, ok)
+					}
+					sort.Strings(oks)
+					for _, ok := range oks {
+						fmt.Fprintf(out, "    %s = %v\n", ok, res.Resolved[k][ok])
+					}
+				}
+			}
+			if len(res.Outputs) > 0 {
+				fmt.Fprintln(out, "\nManifest outputs:")
+				keys := make([]string, 0, len(res.Outputs))
+				for k := range res.Outputs {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					fmt.Fprintf(out, "  %s = %s\n", k, res.Outputs[k])
+				}
+			}
+			return nil
+		},
+	}
+
+	cwd, _ := os.Getwd()
+	cmd.Flags().StringVar(&platformDir, "platform", filepath.Join(cwd, "platform"),
+		"directory holding platform config (resource types, modules, rules, providers)")
+	cmd.Flags().StringVar(&envType, "env-type", "local", "environment type (used by runner/provider rules)")
+	cmd.Flags().StringVar(&stateRoot, "state-root", ".openporch",
+		"directory under which TF state and openporch metadata live")
+	cmd.Flags().StringVar(&tofuBinary, "tofu", "", "path to tofu binary (default: $PATH lookup)")
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false,
+		"validate and render HCL without invoking tofu; prints a per-resource summary")
+	cmd.Flags().StringVar(&renderDir, "render-dir", "",
+		"with --dry-run: write rendered main.tf files here so you can run `tofu plan` manually")
+	cmd.Flags().BoolVar(&planOnly, "plan-only", false,
+		"run `tofu init` and `tofu plan` per resource, persisting the plan; no apply is invoked")
+	return cmd
+}

--- a/cmd/openporch/cmd_rollback_test.go
+++ b/cmd/openporch/cmd_rollback_test.go
@@ -1,0 +1,211 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/krbrudeli/openporch/internal/deploy"
+	"github.com/krbrudeli/openporch/internal/store/db"
+)
+
+// runRollback executes "openporch rollback <args...> --platform <p>
+// --state-root <s> --dry-run" so the pipeline runs through render but skips
+// OpenTofu.
+func runRollback(t *testing.T, stateRoot, platform string, args ...string) (string, error) {
+	t.Helper()
+	root := &cobra.Command{Use: "openporch", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(newRollbackCmd())
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	allArgs := append([]string{"rollback"}, args...)
+	allArgs = append(allArgs, "--state-root", stateRoot, "--platform", platform, "--dry-run")
+	root.SetArgs(allArgs)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// writeRollbackPlatform creates a platform with two modules ("current" and
+// "frozen") for the same resource type. The rule picks "current"; the test
+// seeds a past deployment where the resource was applied with "frozen".
+// A rollback should re-apply with "frozen" — never "current".
+func writeRollbackPlatform(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	platform := `
+apiVersion: openporch/v1alpha1
+kind: ResourceType
+id: workload
+---
+apiVersion: openporch/v1alpha1
+kind: Module
+id: current
+resource_type: workload
+module_source: inline
+module_source_code: |
+  output "ok" { value = "current" }
+---
+apiVersion: openporch/v1alpha1
+kind: Module
+id: frozen
+resource_type: workload
+module_source: inline
+module_source_code: |
+  output "ok" { value = "frozen" }
+---
+apiVersion: openporch/v1alpha1
+kind: ModuleRule
+id: catchall
+resource_type: workload
+module_id: current
+---
+apiVersion: openporch/v1alpha1
+kind: Runner
+id: local-tofu
+type: local-tofu
+---
+apiVersion: openporch/v1alpha1
+kind: RunnerRule
+id: catchall-runner
+runner_id: local-tofu
+`
+	if err := os.WriteFile(filepath.Join(dir, "platform.yaml"), []byte(platform), 0o644); err != nil {
+		t.Fatalf("write platform: %v", err)
+	}
+	return dir
+}
+
+const rollbackManifest = `apiVersion: openporch/v1alpha1
+kind: Application
+metadata:
+  name: test-app
+  project: myproj
+workloads:
+  api:
+    type: workload
+`
+
+// seedRollbackTarget writes a finished deployment whose single resource was
+// applied with the "frozen" module ID — distinct from what rule matching
+// would currently pick.
+func seedRollbackTarget(t *testing.T, stateRoot, project, env, id string) {
+	t.Helper()
+	d, err := db.Open(stateRoot)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer d.Close()
+	rec := db.NewRecorder(d)
+	ctx := context.Background()
+	started := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := rec.StartDeployment(ctx, deploy.DeploymentRecord{
+		ID: id, Project: project, Env: env, EnvType: "local", Mode: "deploy",
+		StartedAt: started, ManifestYAML: rollbackManifest, GraphJSON: `{}`,
+	}); err != nil {
+		t.Fatalf("StartDeployment: %v", err)
+	}
+	if err := rec.RecordResource(ctx, id, deploy.ResourceRecord{
+		ResourceKey: "workload|default|api", Type: "workload", Class: "default",
+		ID: "api", ModuleID: "frozen", RunnerID: "local-tofu",
+		Status: "applied", LogPath: "/tmp/api.log",
+	}); err != nil {
+		t.Fatalf("RecordResource: %v", err)
+	}
+	if err := rec.FinishDeployment(ctx, id, "succeeded", started.Add(time.Minute)); err != nil {
+		t.Fatalf("FinishDeployment: %v", err)
+	}
+}
+
+func TestRollback_PinsToTargetModuleID(t *testing.T) {
+	t.Parallel()
+	platform := writeRollbackPlatform(t)
+	stateRoot := t.TempDir()
+	seedRollbackTarget(t, stateRoot, "myproj", "dev", "dep-frozen")
+
+	out, err := runRollback(t, stateRoot, platform, "myproj", "dev", "dep-frozen")
+	if err != nil {
+		t.Fatalf("runRollback: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Dry-run rollback") {
+		t.Errorf("expected dry-run rollback header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "module=frozen") {
+		t.Errorf("expected module=frozen (pin), got:\n%s", out)
+	}
+	if strings.Contains(out, "module=current") {
+		t.Errorf("rule-matched module 'current' leaked through despite override; got:\n%s", out)
+	}
+}
+
+func TestRollback_DeploymentNotFound(t *testing.T) {
+	t.Parallel()
+	platform := writeRollbackPlatform(t)
+	stateRoot := t.TempDir()
+	_, err := runRollback(t, stateRoot, platform, "myproj", "dev", "missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), `deployment "missing" not found`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRollback_ProjectMismatch(t *testing.T) {
+	t.Parallel()
+	platform := writeRollbackPlatform(t)
+	stateRoot := t.TempDir()
+	seedRollbackTarget(t, stateRoot, "myproj", "dev", "dep-frozen")
+
+	_, err := runRollback(t, stateRoot, platform, "otherproj", "dev", "dep-frozen")
+	if err == nil {
+		t.Fatal("expected project-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), `belongs to project "myproj"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRollback_EnvMismatch(t *testing.T) {
+	t.Parallel()
+	platform := writeRollbackPlatform(t)
+	stateRoot := t.TempDir()
+	seedRollbackTarget(t, stateRoot, "myproj", "dev", "dep-frozen")
+
+	_, err := runRollback(t, stateRoot, platform, "myproj", "prod", "dep-frozen")
+	if err == nil {
+		t.Fatal("expected env-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), `belongs to env "dev"`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRollback_DryRunAndPlanOnlyExclusive(t *testing.T) {
+	t.Parallel()
+	platform := writeRollbackPlatform(t)
+	stateRoot := t.TempDir()
+	seedRollbackTarget(t, stateRoot, "myproj", "dev", "dep-frozen")
+
+	root := &cobra.Command{Use: "openporch", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(newRollbackCmd())
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	root.SetErr(&buf)
+	root.SetArgs([]string{"rollback", "myproj", "dev", "dep-frozen",
+		"--state-root", stateRoot, "--platform", platform,
+		"--dry-run", "--plan-only"})
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/cmd/openporch/main.go
+++ b/cmd/openporch/main.go
@@ -18,7 +18,7 @@ platform-engineer-authored library of OpenTofu modules and rules, picks the
 right module for each (project, env, env_type), and runs OpenTofu to converge.`,
 		SilenceUsage: true,
 	}
-	root.AddCommand(newDeployCmd(), newDestroyCmd(), newValidateCmd(), newGetCmd(), newVersionCmd())
+	root.AddCommand(newDeployCmd(), newDestroyCmd(), newRollbackCmd(), newValidateCmd(), newGetCmd(), newVersionCmd())
 
 	if err := root.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -56,6 +56,19 @@ type Options struct {
 	// recorded with mode=plan_only and a terminal status of `planned` (or
 	// `plan_failed`). No `tofu apply` is invoked; no outputs are produced.
 	PlanOnly bool
+
+	// ModuleOverrides pins module selection per resource key, bypassing
+	// platform rule matching for any node whose key has an entry here.
+	// Used by rollback to freeze module IDs to a past deployment's
+	// resolved set so module-rule changes after that deployment do not
+	// affect the rollback's module selection. Nodes not in the map fall
+	// back to rule matching as usual.
+	ModuleOverrides map[string]string
+
+	// Mode optionally overrides the deployment mode recorded on the row.
+	// When empty the pipeline picks "deploy" (or "plan_only" when
+	// PlanOnly is set). Used by rollback to record mode="rollback".
+	Mode string
 }
 
 // runnerID returns a stable identifier for the runner type so it can be
@@ -170,13 +183,19 @@ func (s stateView) AliasOutputs(alias string) (map[string]any, bool) {
 }
 
 // resolverFromMatcher adapts the rule engine into graph.ModuleResolver.
+// Overrides, when non-nil, take precedence over rule matching: any node whose
+// Key is present returns its pinned module ID without consulting the rules.
 type resolverFromMatcher struct {
-	rules []v1.ModuleRule
-	known map[string]v1.ResourceType
-	ctx   match.Context
+	rules     []v1.ModuleRule
+	known     map[string]v1.ResourceType
+	ctx       match.Context
+	overrides map[string]string
 }
 
 func (r resolverFromMatcher) Resolve(n *graph.Node) (string, error) {
+	if id, ok := r.overrides[n.Key]; ok {
+		return id, nil
+	}
 	if _, ok := r.known[n.Type]; !ok {
 		// Unknown resource type — likely an unintended dep target. Skip.
 		return "", graph.ErrSkipModuleResolution
@@ -202,7 +221,10 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 		EnvID:     o.EnvID,
 		EnvTypeID: o.EnvTypeID,
 	}
-	res := resolverFromMatcher{rules: o.Platform.ModuleRules, known: o.Platform.ResourceTypes, ctx: mctx}
+	res := resolverFromMatcher{
+		rules: o.Platform.ModuleRules, known: o.Platform.ResourceTypes,
+		ctx: mctx, overrides: o.ModuleOverrides,
+	}
 	g, err := graph.Build(o.Manifest, o.Platform.Modules, res)
 	if err != nil {
 		return nil, fmt.Errorf("deploy: build graph: %w", err)
@@ -238,9 +260,12 @@ func Run(ctx context.Context, o Options) (*Result, error) {
 
 	startedAt := time.Now().UTC()
 	if o.Recorder != nil && !o.DryRun {
-		mode := "deploy"
-		if o.PlanOnly {
-			mode = "plan_only"
+		mode := o.Mode
+		if mode == "" {
+			mode = "deploy"
+			if o.PlanOnly {
+				mode = "plan_only"
+			}
 		}
 		manifestYAML, _ := yaml.Marshal(o.Manifest)
 		graphJSON, _ := serializeGraph(g)

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -625,3 +625,127 @@ func TestRenderGraph_NilInputs(t *testing.T) {
 		t.Error("expected error for nil graph, got nil")
 	}
 }
+
+// twoModulePlatform has two modules for the same resource type. The rule
+// picks "current"; tests use ModuleOverrides to force "frozen" instead so we
+// can verify rollback's pin overrides the current rules.
+func twoModulePlatform(t *testing.T) *v1.PlatformConfig {
+	t.Helper()
+	return &v1.PlatformConfig{
+		RootDir: t.TempDir(),
+		ResourceTypes: map[string]v1.ResourceType{
+			"workload": {ID: "workload"},
+		},
+		Modules: map[string]v1.Module{
+			"current": {
+				ID: "current", ResourceType: "workload",
+				ModuleSource: "inline", ModuleSourceCode: ``,
+			},
+			"frozen": {
+				ID: "frozen", ResourceType: "workload",
+				ModuleSource: "inline", ModuleSourceCode: ``,
+			},
+		},
+		ModuleRules: []v1.ModuleRule{
+			{ID: "catchall", ResourceType: "workload", ModuleID: "current"},
+		},
+		Providers: map[string]v1.Provider{},
+		Runners:   map[string]v1.Runner{},
+	}
+}
+
+func TestRun_ModuleOverridesPinModuleID(t *testing.T) {
+	t.Parallel()
+	capRec := &captureRecorder{}
+	_, err := Run(context.Background(), Options{
+		Manifest:  minimalManifest(),
+		Platform:  twoModulePlatform(t),
+		Store:     &storetest.Fake{},
+		Runner:    &runnertest.Recording{},
+		RunnerID:  "local-tofu",
+		ProjectID: "proj",
+		EnvID:     "test",
+		EnvTypeID: "local",
+		Recorder:  capRec,
+		ModuleOverrides: map[string]string{
+			"workload|default|api": "frozen",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	last := map[string]ResourceRecord{}
+	for _, r := range capRec.resources {
+		last[r.ResourceKey] = r
+	}
+	got, ok := last["workload|default|api"]
+	if !ok {
+		t.Fatalf("workload|default|api was not recorded; got keys: %v", keys(last))
+	}
+	if got.ModuleID != "frozen" {
+		t.Errorf("ModuleID = %q, want frozen (override should bypass rules)", got.ModuleID)
+	}
+}
+
+func TestRun_ModuleOverridesFallBackToRulesForUnpinnedNodes(t *testing.T) {
+	t.Parallel()
+	capRec := &captureRecorder{}
+	// Overrides intentionally empty — pipeline must still use rule matching.
+	_, err := Run(context.Background(), Options{
+		Manifest:        minimalManifest(),
+		Platform:        twoModulePlatform(t),
+		Store:           &storetest.Fake{},
+		Runner:          &runnertest.Recording{},
+		RunnerID:        "local-tofu",
+		ProjectID:       "proj",
+		EnvID:           "test",
+		EnvTypeID:       "local",
+		Recorder:        capRec,
+		ModuleOverrides: map[string]string{},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	last := map[string]ResourceRecord{}
+	for _, r := range capRec.resources {
+		last[r.ResourceKey] = r
+	}
+	got := last["workload|default|api"]
+	if got.ModuleID != "current" {
+		t.Errorf("ModuleID = %q, want current (rules should apply when overrides empty)", got.ModuleID)
+	}
+}
+
+func TestRun_RollbackModeIsRecorded(t *testing.T) {
+	t.Parallel()
+	gotMode := ""
+	rec := &startCapturingRecorder{
+		onStart: func(d DeploymentRecord) { gotMode = d.Mode },
+	}
+	if _, err := Run(context.Background(), Options{
+		Manifest:        minimalManifest(),
+		Platform:        twoModulePlatform(t),
+		Store:           &storetest.Fake{},
+		Runner:          &runnertest.Recording{},
+		RunnerID:        "local-tofu",
+		ProjectID:       "proj",
+		EnvID:           "test",
+		EnvTypeID:       "local",
+		Recorder:        rec,
+		Mode:            "rollback",
+		ModuleOverrides: map[string]string{"workload|default|api": "frozen"},
+	}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if gotMode != "rollback" {
+		t.Errorf("StartDeployment Mode = %q, want rollback", gotMode)
+	}
+}
+
+func keys(m map[string]ResourceRecord) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/deploy/destroy.go
+++ b/internal/deploy/destroy.go
@@ -135,7 +135,10 @@ func buildGraph(o Options) (*graph.Graph, error) {
 		EnvID:     o.EnvID,
 		EnvTypeID: o.EnvTypeID,
 	}
-	res := resolverFromMatcher{rules: o.Platform.ModuleRules, known: o.Platform.ResourceTypes, ctx: mctx}
+	res := resolverFromMatcher{
+		rules: o.Platform.ModuleRules, known: o.Platform.ResourceTypes,
+		ctx: mctx, overrides: o.ModuleOverrides,
+	}
 	g, err := graph.Build(o.Manifest, o.Platform.Modules, res)
 	if err != nil {
 		return nil, err

--- a/internal/deploy/recorder.go
+++ b/internal/deploy/recorder.go
@@ -43,7 +43,7 @@ type DeploymentRecord struct {
 	Project      string
 	Env          string
 	EnvType      string
-	Mode         string // "deploy" or "destroy"
+	Mode         string // "deploy", "destroy", "plan_only", or "rollback"
 	StartedAt    time.Time
 	ManifestYAML string
 	GraphJSON    string

--- a/internal/store/db/reader.go
+++ b/internal/store/db/reader.go
@@ -172,6 +172,33 @@ func (r *Reader) GetLastSuccessfulDeployment(ctx context.Context, project, env s
 	return r.GetDeployment(ctx, id)
 }
 
+// GetDeploymentModuleAssignments returns a resource_key -> module_id map for
+// the given deployment. Used by `opo rollback` to pin module selection to
+// what a past deployment resolved, bypassing the current rule set. Returns an
+// empty map if the deployment has no resources or doesn't exist; callers
+// should verify the deployment via GetDeployment first if presence matters.
+func (r *Reader) GetDeploymentModuleAssignments(ctx context.Context, deploymentID string) (map[string]string, error) {
+	rows, err := r.db.QueryContext(ctx,
+		`SELECT resource_key, module_id FROM deployment_resources
+		 WHERE deployment_id = ?`, deploymentID)
+	if err != nil {
+		return nil, fmt.Errorf("db: get deployment module assignments: %w", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var k, m string
+		if err := rows.Scan(&k, &m); err != nil {
+			return nil, fmt.Errorf("db: scan module assignment row: %w", err)
+		}
+		out[k] = m
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("db: get deployment module assignments: %w", err)
+	}
+	return out, nil
+}
+
 // ListActiveResources returns the active resources for (project, env),
 // ordered by resource_key.
 func (r *Reader) ListActiveResources(ctx context.Context, project, env string) ([]ActiveResourceRow, error) {

--- a/internal/store/db/reader_test.go
+++ b/internal/store/db/reader_test.go
@@ -436,3 +436,53 @@ func TestGetDeployment_FinishedAtEmpty(t *testing.T) {
 		t.Errorf("Status = %q, want running", det.Status)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// GetDeploymentModuleAssignments
+// ---------------------------------------------------------------------------
+
+func TestGetDeploymentModuleAssignments_ReturnsKeyedMap(t *testing.T) {
+	t.Parallel()
+	_, rec, rdr := openTestDB(t)
+	mustSeed(t, rec, deploy.DeploymentRecord{
+		ID: "dep-1", Project: "p", Env: "e", EnvType: "local", Mode: "deploy",
+		StartedAt:    time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		ManifestYAML: "kind: Manifest\n", GraphJSON: `{}`,
+	}, true, []deploy.ResourceRecord{
+		{ResourceKey: "workload|default|api", Type: "workload", Class: "default",
+			ID: "api", ModuleID: "mod-svc-v1", RunnerID: "local-tofu",
+			Status: "applied", LogPath: "/tmp/api.log"},
+		{ResourceKey: "database|default|db", Type: "database", Class: "default",
+			ID: "db", ModuleID: "mod-pg-v2", RunnerID: "local-tofu",
+			Status: "applied", LogPath: "/tmp/db.log"},
+	})
+
+	got, err := rdr.GetDeploymentModuleAssignments(context.Background(), "dep-1")
+	if err != nil {
+		t.Fatalf("GetDeploymentModuleAssignments: %v", err)
+	}
+	want := map[string]string{
+		"workload|default|api": "mod-svc-v1",
+		"database|default|db":  "mod-pg-v2",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d entries, want %d", len(got), len(want))
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("got[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestGetDeploymentModuleAssignments_EmptyForUnknownDeployment(t *testing.T) {
+	t.Parallel()
+	_, _, rdr := openTestDB(t)
+	got, err := rdr.GetDeploymentModuleAssignments(context.Background(), "no-such")
+	if err != nil {
+		t.Fatalf("GetDeploymentModuleAssignments: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map for unknown deployment, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `opo rollback <project> <env> <deployment-id>`: replays the target deployment's manifest with module IDs **frozen** to that deployment's resolved set, bypassing current module rules. Provider/runner config still comes from current platform state. The new deployment is recorded with `mode=rollback`.
- Plumbs `Options.ModuleOverrides` + `Options.Mode` through `internal/deploy`; the resolver consults overrides before rule matching.
- Adds `db.Reader.GetDeploymentModuleAssignments` returning `resource_key -> module_id` for a deployment.

Closes #43.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...` and `go vet -tags=integration ./...`
- [x] `go test -race -count=1 ./...`
- [x] Unit tests in `internal/deploy/` cover: override pins module, empty override falls back to rules, rollback mode is recorded.
- [x] Reader test covers `GetDeploymentModuleAssignments` happy path + unknown deployment.
- [x] CLI tests cover: rollback pins target module (rule-matched module never leaks through), deployment-not-found, project mismatch, env mismatch, `--dry-run`+`--plan-only` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)